### PR TITLE
WIP: support static access-token authentication

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,4 @@
-NAME=scaffolding
+NAME=googlecompute
 BINARY=packer-plugin-${NAME}
 
 COUNT?=1

--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -40,6 +40,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		Ui:                            ui,
 		ProjectId:                     b.config.ProjectId,
 		Account:                       b.config.account,
+		AccessToken:                   b.config.AccessToken,
 		ImpersonateServiceAccountName: b.config.ImpersonateServiceAccount,
 		VaultOauthEngineName:          b.config.VaultGCPOauthEngine,
 	}

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -67,6 +67,7 @@ type FlatConfig struct {
 	WinRMUseSSL                  *bool                      `mapstructure:"winrm_use_ssl" cty:"winrm_use_ssl" hcl:"winrm_use_ssl"`
 	WinRMInsecure                *bool                      `mapstructure:"winrm_insecure" cty:"winrm_insecure" hcl:"winrm_insecure"`
 	WinRMUseNTLM                 *bool                      `mapstructure:"winrm_use_ntlm" cty:"winrm_use_ntlm" hcl:"winrm_use_ntlm"`
+	AccessToken                  *string                    `mapstructure:"access_token" required:"false" cty:"access_token" hcl:"access_token"`
 	AccountFile                  *string                    `mapstructure:"account_file" required:"false" cty:"account_file" hcl:"account_file"`
 	ImpersonateServiceAccount    *string                    `mapstructure:"impersonate_service_account" required:"false" cty:"impersonate_service_account" hcl:"impersonate_service_account"`
 	ProjectId                    *string                    `mapstructure:"project_id" required:"true" cty:"project_id" hcl:"project_id"`
@@ -192,6 +193,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"winrm_use_ssl":                   &hcldec.AttrSpec{Name: "winrm_use_ssl", Type: cty.Bool, Required: false},
 		"winrm_insecure":                  &hcldec.AttrSpec{Name: "winrm_insecure", Type: cty.Bool, Required: false},
 		"winrm_use_ntlm":                  &hcldec.AttrSpec{Name: "winrm_use_ntlm", Type: cty.Bool, Required: false},
+		"access_token":                    &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"account_file":                    &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
 		"impersonate_service_account":     &hcldec.AttrSpec{Name: "impersonate_service_account", Type: cty.String, Required: false},
 		"project_id":                      &hcldec.AttrSpec{Name: "project_id", Type: cty.String, Required: false},

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -1,5 +1,15 @@
 <!-- Code generated from the comments of the Config struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
 
+- `access_token` (string) - A temporary [OAuth 2.0 access token](https://developers.google.com/identity/protocols/oauth2)
+  obtained from the Google Authorization server, i.e. the `Authorization: Bearer` token used to
+  authenticate HTTP requests to GCP APIs.
+  This is an alternative to `account_file`, and ignores the `scopes` field.
+  If both are specified, `access_token` will be used over the `account_file` field.
+  
+  These access tokens cannot be renewed by Packer and thus will only work until they expire.
+  If you anticipate Packer needing access for longer than a token's lifetime (default `1 hour`),
+  please use a service account key with `account_file` instead.
+
 - `account_file` (string) - The JSON file containing your account credentials. Not required if you
   run Packer on a GCE instance with a service account. Instructions for
   creating the file or using service accounts are above.

--- a/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
+++ b/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
@@ -1,5 +1,7 @@
 <!-- Code generated from the comments of the Config struct in post-processor/googlecompute-export/post-processor.go; DO NOT EDIT MANUALLY -->
 
+- `access_token` (string) - A temporary OAuth 2.0 access token
+
 - `account_file` (string) - The JSON file containing your account credentials.
   If specified, the account file will take precedence over any `googlecompute` builder authentication method.
 

--- a/docs-partials/post-processor/googlecompute-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/googlecompute-import/Config-not-required.mdx
@@ -1,5 +1,10 @@
 <!-- Code generated from the comments of the Config struct in post-processor/googlecompute-import/post-processor.go; DO NOT EDIT MANUALLY -->
 
+- `access_token` (string) - A temporary OAuth 2.0 access token
+
+- `account_file` (string) - The JSON file containing your account credentials.
+  If specified, the account file will take precedence over any `googlecompute` builder authentication method.
+
 - `impersonate_service_account` (string) - This allows service account impersonation as per the [docs](https://cloud.google.com/iam/docs/impersonating-service-accounts).
 
 - `gcs_object_name` (string) - The name of the GCS object in `bucket` where

--- a/docs-partials/post-processor/googlecompute-import/Config-required.mdx
+++ b/docs-partials/post-processor/googlecompute-import/Config-required.mdx
@@ -1,8 +1,5 @@
 <!-- Code generated from the comments of the Config struct in post-processor/googlecompute-import/post-processor.go; DO NOT EDIT MANUALLY -->
 
-- `account_file` (string) - The JSON file containing your account credentials.
-  If specified, the account file will take precedence over any `googlecompute` builder authentication method.
-
 - `project_id` (string) - The project ID where the GCS bucket exists and where the GCE image is stored.
 
 - `bucket` (string) - The name of the GCS bucket where the raw disk image will be uploaded.

--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -41,8 +41,8 @@ packer {
 
 ## Authentication
 
-Authenticating with Google Cloud services requires either a User Application Default Credentials
-or a JSON Service Account Key. These are **not** required if you are
+Authenticating with Google Cloud services requires either a User Application Default Credentials, 
+a JSON Service Account Key or an Access Token.  These are **not** required if you are
 running the `googlecompute` Packer builder on Google Cloud with a
 properly-configured [Google Service
 Account](https://cloud.google.com/compute/docs/authentication).
@@ -121,12 +121,14 @@ straightforwarded, it is documented here.
 Packer looks for credentials in the following places, preferring the first
 location found:
 
-1.  An `account_file` option in your packer file.
+1.  An `access_token` option in your packer file.
 
-2.  A JSON file (Service Account) whose path is specified by the
+2.  An `account_file` option in your packer file.
+
+3.  A JSON file (Service Account) whose path is specified by the
     `GOOGLE_APPLICATION_CREDENTIALS` environment variable.
 
-3.  A JSON file in a location known to the `gcloud` command-line tool.
+4.  A JSON file in a location known to the `gcloud` command-line tool.
     (`gcloud auth application-default login` creates it)
 
     On Windows, this is:
@@ -137,7 +139,7 @@ location found:
 
         $HOME/.config/gcloud/application_default_credentials.json
 
-4.  On Google Compute Engine and Google App Engine Managed VMs, it fetches
+5.  On Google Compute Engine and Google App Engine Managed VMs, it fetches
     credentials from the metadata server. (Needs a correct VM authentication
     scope configuration, see above.)
 

--- a/post-processor/googlecompute-export/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-export/post-processor.hcl2spec.go
@@ -18,7 +18,8 @@ type FlatConfig struct {
 	PackerOnError             *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars            map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars       []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	AccountFile               *string           `mapstructure:"account_file" cty:"account_file" hcl:"account_file"`
+	AccessToken               *string           `mapstructure:"access_token" required:"false" cty:"access_token" hcl:"access_token"`
+	AccountFile               *string           `mapstructure:"account_file" required:"false" cty:"account_file" hcl:"account_file"`
 	ImpersonateServiceAccount *string           `mapstructure:"impersonate_service_account" required:"false" cty:"impersonate_service_account" hcl:"impersonate_service_account"`
 	DiskSizeGb                *int64            `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	DiskType                  *string           `mapstructure:"disk_type" cty:"disk_type" hcl:"disk_type"`
@@ -51,6 +52,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":             &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":       &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":  &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"access_token":                &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"account_file":                &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
 		"impersonate_service_account": &hcldec.AttrSpec{Name: "impersonate_service_account", Type: cty.String, Required: false},
 		"disk_size":                   &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},

--- a/post-processor/googlecompute-import/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-import/post-processor.hcl2spec.go
@@ -18,7 +18,8 @@ type FlatConfig struct {
 	PackerOnError              *string           `mapstructure:"packer_on_error" cty:"packer_on_error" hcl:"packer_on_error"`
 	PackerUserVars             map[string]string `mapstructure:"packer_user_variables" cty:"packer_user_variables" hcl:"packer_user_variables"`
 	PackerSensitiveVars        []string          `mapstructure:"packer_sensitive_variables" cty:"packer_sensitive_variables" hcl:"packer_sensitive_variables"`
-	AccountFile                *string           `mapstructure:"account_file" required:"true" cty:"account_file" hcl:"account_file"`
+	AccessToken                *string           `mapstructure:"access_token" required:"false" cty:"access_token" hcl:"access_token"`
+	AccountFile                *string           `mapstructure:"account_file" required:"false" cty:"account_file" hcl:"account_file"`
 	ImpersonateServiceAccount  *string           `mapstructure:"impersonate_service_account" required:"false" cty:"impersonate_service_account" hcl:"impersonate_service_account"`
 	ProjectId                  *string           `mapstructure:"project_id" required:"true" cty:"project_id" hcl:"project_id"`
 	IAP                        *bool             `mapstructure-to-hcl:",skip" cty:"iap" hcl:"iap"`
@@ -58,6 +59,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"packer_on_error":               &hcldec.AttrSpec{Name: "packer_on_error", Type: cty.String, Required: false},
 		"packer_user_variables":         &hcldec.AttrSpec{Name: "packer_user_variables", Type: cty.Map(cty.String), Required: false},
 		"packer_sensitive_variables":    &hcldec.AttrSpec{Name: "packer_sensitive_variables", Type: cty.List(cty.String), Required: false},
+		"access_token":                  &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"account_file":                  &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
 		"impersonate_service_account":   &hcldec.AttrSpec{Name: "impersonate_service_account", Type: cty.String, Required: false},
 		"project_id":                    &hcldec.AttrSpec{Name: "project_id", Type: cty.String, Required: false},


### PR DESCRIPTION
Hello,

I need to have Packer support static access token to authenticate on Google API.

This is supported by Terraform, and I tried to implement it in Packer.
https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#access_token

It's the first time I contribute to Packer. Tell me if anything is wrong and I will fix it.

I did the following tests that is working

```shell
export PKR_VAR_access_token=$(gcloud auth application-default print-access-token)  
packer build example/build.pkr.hcl 
```

```hcl
# cat build example/build.pkr.hcl 
variable "zone" {
  default = "europe-west4-a"
}

variable "project_id" {
  type = string
  default = "fra-demo-ccc-dev-demo"
}

variable "access_token" {
  type = string
  sensitive = true
}

source "googlecompute" "ex" {
  access_token            = var.access_token
  image_name              = "test-packer-example"
  machine_type            = "e2-small"
  source_image            = "debian-10-buster-v20210316"
  ssh_username            = "packer"
  temporary_key_pair_type = "rsa"
  temporary_key_pair_bits = 2048
  zone                    = var.zone
  project_id              = var.project_id
}

build {
  sources = ["source.googlecompute.ex"]
  provisioner "shell" {
    inline = [
      "echo Hello From ${source.type} ${source.name}"
    ]
  }
}
```

Now I need to test the post-processors