### PR TITLE
Fix Error 400: Invalid value for field 'resource.sourceDisk

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -176,7 +176,7 @@ func (d *driverGCE) CreateImage(name, description, family, zone, disk string, im
 		Labels:             image_labels,
 		Licenses:           image_licenses,
 		ImageEncryptionKey: image_encryption_key,
-		SourceDisk:         fmt.Sprintf("%s%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
+		SourceDisk:         fmt.Sprintf("%sprojects/%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:         "RAW",
 		StorageLocations:   imageStorageLocations,
 	}


### PR DESCRIPTION
Fix Error 400: Invalid value for field 'resource.sourceDisk' #15

