### PR TITLE
IAP support works with all credentials for a googlecompute builder

### DIFF
--- a/builder/googlecompute/step_start_tunnel.go
+++ b/builder/googlecompute/step_start_tunnel.go
@@ -31,7 +31,7 @@ type IAPConfig struct {
 	// Prerequisites and limitations for using IAP:
 	// - You must manually enable the IAP API in the Google Cloud console.
 	// - You must have the gcloud sdk installed on the computer running Packer.
-	// - If you use a service account to project level IAP permissions
+	// - If you use a service account, you must add it to project level IAP permissions
 	//   in https://console.cloud.google.com/security/iap. To do so, click
 	//   "project" > "SSH and TCP resources" > "All Tunnel Resources" >
 	//   "Add Member". Then add your service account and choose the role

--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -64,15 +64,14 @@ func TestStepStartTunnel_CreateTempScript(t *testing.T) {
 	}
 
 	expected := `#!/bin/bash
-
-gcloud auth activate-service-account --key-file='/path/to/account_file.json'
+CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE='/path/to/account_file.json'
+export CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE
 gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b --project fake-project-123
 `
 	if runtime.GOOS == "windows" {
 		// in real life you'd not be passing a HashBang here, but GIGO.
 		expected = `#!/bin/bash
-
-call gcloud auth activate-service-account --key-file "/path/to/account_file.json"
+set "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=/path/to/account_file.json"
 call gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b --project fake-project-123
 `
 	}

--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -83,6 +83,10 @@ $ gcloud projects add-iam-policy-binding YOUR_GCP_PROJECT \
     --member=serviceAccount:packer@YOUR_GCP_PROJECT.iam.gserviceaccount.com \
     --role=roles/iam.serviceAccountUser
 
+$ gcloud projects add-iam-policy-binding YOUR_GCP_PROJECT \
+    --member=serviceAccount:packer@YOUR_GCP_PROJECT.iam.gserviceaccount.com \
+    --role=roles/iap.tunnelResourceAccessor
+
 $ gcloud compute instances create INSTANCE-NAME \
   --project YOUR_GCP_PROJECT \
   --image-family ubuntu-2004-lts \


### PR DESCRIPTION
IAP support no longer requires a service account file to work. it will work with the googlecompute account_file, GOOGLE_APPLICATION_CREDENTIALS and default credentials.

Closes #3
