### PR TITLE
Customer-managed Encryption Key for Remote VM's Boot Disk #20

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -69,6 +69,24 @@ type Config struct {
 	// Type of disk used to back your instance, like pd-ssd or pd-standard.
 	// Defaults to pd-standard.
 	DiskType string `mapstructure:"disk_type" required:"false"`
+	// Disk encryption key to apply to the created boot disk. Possible values:
+	// * kmsKeyName -  The name of the encryption key that is stored in Google Cloud KMS.
+	// * RawKey: - A 256-bit customer-supplied encryption key, encodes in RFC 4648 base64.
+	//
+	// examples:
+	//
+	//  ```json
+	//  {
+	//     "kmsKeyName": "projects/${project}/locations/${region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+	//  }
+	//  ```
+	//
+	//  ```hcl
+	//   disk_encryption_key {
+	//     kmsKeyName = "projects/${var.project}/locations/${var.region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+	//   }
+	//  ```
+	DiskEncryptionKey *CustomerEncryptionKey `mapstructure:"disk_encryption_key" required:"false"`
 	// Create a Shielded VM image with Secure Boot enabled. It helps ensure that
 	// the system only runs authentic software by verifying the digital signature
 	// of all boot components, and halting the boot process if signature verification

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -78,6 +78,7 @@ type FlatConfig struct {
 	DiskName                     *string                    `mapstructure:"disk_name" required:"false" cty:"disk_name" hcl:"disk_name"`
 	DiskSizeGb                   *int64                     `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	DiskType                     *string                    `mapstructure:"disk_type" required:"false" cty:"disk_type" hcl:"disk_type"`
+	DiskEncryptionKey            *FlatCustomerEncryptionKey `mapstructure:"disk_encryption_key" required:"false" cty:"disk_encryption_key" hcl:"disk_encryption_key"`
 	EnableSecureBoot             *bool                      `mapstructure:"enable_secure_boot" required:"false" cty:"enable_secure_boot" hcl:"enable_secure_boot"`
 	EnableVtpm                   *bool                      `mapstructure:"enable_vtpm" required:"false" cty:"enable_vtpm" hcl:"enable_vtpm"`
 	EnableIntegrityMonitoring    *bool                      `mapstructure:"enable_integrity_monitoring" required:"false" cty:"enable_integrity_monitoring" hcl:"enable_integrity_monitoring"`
@@ -204,6 +205,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_name":                       &hcldec.AttrSpec{Name: "disk_name", Type: cty.String, Required: false},
 		"disk_size":                       &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_type":                       &hcldec.AttrSpec{Name: "disk_type", Type: cty.String, Required: false},
+		"disk_encryption_key":             &hcldec.BlockSpec{TypeName: "disk_encryption_key", Nested: hcldec.ObjectSpec((*FlatCustomerEncryptionKey)(nil).HCL2Spec())},
 		"enable_secure_boot":              &hcldec.AttrSpec{Name: "enable_secure_boot", Type: cty.Bool, Required: false},
 		"enable_vtpm":                     &hcldec.AttrSpec{Name: "enable_vtpm", Type: cty.Bool, Required: false},
 		"enable_integrity_monitoring":     &hcldec.AttrSpec{Name: "enable_integrity_monitoring", Type: cty.Bool, Required: false},

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -244,6 +244,21 @@ func TestConfigPrepare(t *testing.T) {
 			"NOT A BOOL",
 			true,
 		},
+		{
+			"disk_encryption_key",
+			map[string]string{"kmsKeyName": "foo"},
+			false,
+		},
+		{
+			"disk_encryption_key",
+			map[string]string{"No such key": "foo"},
+			true,
+		},
+		{
+			"disk_encryption_key",
+			map[string]string{"kmsKeyName": "foo", "RawKey": "foo"},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -82,6 +82,7 @@ type InstanceConfig struct {
 	DisableDefaultServiceAccount bool
 	DiskSizeGb                   int64
 	DiskType                     string
+	DiskEncryptionKey            *CustomerEncryptionKey
 	EnableSecureBoot             bool
 	EnableVtpm                   bool
 	EnableIntegrityMonitoring    bool

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -171,6 +171,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		DisableDefaultServiceAccount: c.DisableDefaultServiceAccount,
 		DiskSizeGb:                   c.DiskSizeGb,
 		DiskType:                     c.DiskType,
+		DiskEncryptionKey:            c.DiskEncryptionKey,
 		EnableSecureBoot:             c.EnableSecureBoot,
 		EnableVtpm:                   c.EnableVtpm,
 		EnableIntegrityMonitoring:    c.EnableIntegrityMonitoring,

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -37,6 +37,24 @@
 - `disk_type` (string) - Type of disk used to back your instance, like pd-ssd or pd-standard.
   Defaults to pd-standard.
 
+- `disk_encryption_key` (\*CustomerEncryptionKey) - Disk encryption key to apply to the created boot disk. Possible values:
+  * kmsKeyName -  The name of the encryption key that is stored in Google Cloud KMS.
+  * RawKey: - A 256-bit customer-supplied encryption key, encodes in RFC 4648 base64.
+  
+  examples:
+  
+   ```json
+   {
+      "kmsKeyName": "projects/${project}/locations/${region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+   }
+   ```
+  
+   ```hcl
+    disk_encryption_key {
+      kmsKeyName = "projects/${var.project}/locations/${var.region}/keyRings/computeEngine/cryptoKeys/computeEngine/cryptoKeyVersions/4"
+    }
+   ```
+
 - `enable_secure_boot` (bool) - Create a Shielded VM image with Secure Boot enabled. It helps ensure that
   the system only runs authentic software by verifying the digital signature
   of all boot components, and halting the boot process if signature verification


### PR DESCRIPTION
To support Customer-managed Encryption Key for Remote VM's Boot Disk #20
End to end test [results](https://gist.github.com/wilsonfv/456af7aa688a0fe68d8705d30711753f) 


[Without disk_encryption_key](https://gist.github.com/wilsonfv/456af7aa688a0fe68d8705d30711753f#file-packer_disk_encryption_key_empty-json), default behavior will be using google-managed encryption key.
A debug log will be output similar to [below](https://gist.github.com/wilsonfv/456af7aa688a0fe68d8705d30711753f#file-packer_disk_encryption_key_empty-json-log-L56) 
> 2021/05/08 14:24:22 packer-plugin-googlecompute plugin: 2021/05/08 14:24:22 [DEBUG] using google-managed encryption key for boot disk


With disk_encryption_key [specified](https://gist.github.com/wilsonfv/456af7aa688a0fe68d8705d30711753f#file-packer_disk_encryption_key_populate-json-L11-L13), will use customer-managed encryption key for remote VM's boot disk.
A debug log will be output similar to [below](https://gist.github.com/wilsonfv/456af7aa688a0fe68d8705d30711753f#file-packer_disk_encryption_key_populate-json-L11-L13) 
> 2021/05/08 14:32:01 packer-plugin-googlecompute plugin: 2021/05/08 14:32:01 [DEBUG] using customer-managed encryption key for boot disk, KmsKeyName=projects/gke-eu-1/locations/global/keyRings/compute/cryptoKeys/compute, RawKey=

On gcp console, we can see packer remote VM boot disk is using customer-managed encryption key
![image](https://user-images.githubusercontent.com/4541194/117529969-54e09580-b00d-11eb-98bf-7fc8e29a96b4.png)

When look into packer remote VM boot disk details, we can see it is using the CMEK we have provided
![image](https://user-images.githubusercontent.com/4541194/117530016-7b063580-b00d-11eb-9cbd-dc8c46acf8c9.png)


Thanks @krzyszko 's image encryption key [changes](https://github.com/hashicorp/packer/issues/7307) as reference 

Closes #20 


