### PR TITLE
Allow distinct image project ids

### DIFF
--- a/builder/googlecompute/artifact.go
+++ b/builder/googlecompute/artifact.go
@@ -23,7 +23,7 @@ func (*Artifact) BuilderId() string {
 // Destroy destroys the GCE image represented by the artifact.
 func (a *Artifact) Destroy() error {
 	log.Printf("Destroying image: %s", a.image.Name)
-	errCh := a.driver.DeleteImage(a.image.Name)
+	errCh := a.driver.DeleteImage(a.config.ImageProjectId, a.image.Name)
 	return <-errCh
 }
 
@@ -39,7 +39,8 @@ func (a *Artifact) Id() string {
 
 // String returns the string representation of the artifact.
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A disk image was created: %v", a.image.Name)
+	return fmt.Sprintf("A disk image was created in the '%v' project: %v",
+		a.config.ImageProjectId, a.image.Name)
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	ImageLabels map[string]string `mapstructure:"image_labels" required:"false"`
 	// Licenses to apply to the created image.
 	ImageLicenses []string `mapstructure:"image_licenses" required:"false"`
+	// The project ID to push the build image into. Defaults to project_id.
+	ImageProjectId string `mapstructure:"image_project_id" required:"false"`
 	// Storage location, either regional or multi-regional, where snapshot
 	// content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional
 	// location.
@@ -348,6 +350,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.DiskType == "" {
 		c.DiskType = "pd-standard"
+	}
+
+	if c.ImageProjectId == "" {
+		c.ImageProjectId = c.ProjectId
 	}
 
 	// Disabling the vTPM also disables integrity monitoring, because integrity

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -93,6 +93,7 @@ type FlatConfig struct {
 	ImageFamily                  *string                    `mapstructure:"image_family" required:"false" cty:"image_family" hcl:"image_family"`
 	ImageLabels                  map[string]string          `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
 	ImageLicenses                []string                   `mapstructure:"image_licenses" required:"false" cty:"image_licenses" hcl:"image_licenses"`
+	ImageProjectId               *string                    `mapstructure:"image_project_id" required:"false" cty:"image_project_id" hcl:"image_project_id"`
 	ImageStorageLocations        []string                   `mapstructure:"image_storage_locations" required:"false" cty:"image_storage_locations" hcl:"image_storage_locations"`
 	InstanceName                 *string                    `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	Labels                       map[string]string          `mapstructure:"labels" required:"false" cty:"labels" hcl:"labels"`
@@ -219,6 +220,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_family":                    &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"image_labels":                    &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},
 		"image_licenses":                  &hcldec.AttrSpec{Name: "image_licenses", Type: cty.List(cty.String), Required: false},
+		"image_project_id":                &hcldec.AttrSpec{Name: "image_project_id", Type: cty.String, Required: false},
 		"image_storage_locations":         &hcldec.AttrSpec{Name: "image_storage_locations", Type: cty.List(cty.String), Required: false},
 		"instance_name":                   &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"labels":                          &hcldec.AttrSpec{Name: "labels", Type: cty.Map(cty.String), Required: false},

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -14,10 +14,10 @@ import (
 type Driver interface {
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
+	CreateImage(project, name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
-	DeleteImage(name string) <-chan error
+	DeleteImage(project, name string) <-chan error
 
 	// DeleteInstance deletes the given instance, keeping the boot disk.
 	DeleteInstance(zone, name string) (<-chan error, error)
@@ -53,7 +53,7 @@ type Driver interface {
 
 	// ImageExists returns true if the specified image exists. If an error
 	// occurs calling the API, this method returns false.
-	ImageExists(name string) bool
+	ImageExists(project, name string) bool
 
 	// RunInstance takes the given config and launches an instance.
 	RunInstance(*InstanceConfig) (<-chan error, error)

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -168,7 +168,7 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 	}, nil
 }
 
-func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
+func (d *driverGCE) CreateImage(project, name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
 	gce_image := &compute.Image{
 		Description:        description,
 		Name:               name,
@@ -183,19 +183,19 @@ func (d *driverGCE) CreateImage(name, description, family, zone, disk string, im
 
 	imageCh := make(chan *Image, 1)
 	errCh := make(chan error, 1)
-	op, err := d.service.Images.Insert(d.projectId, gce_image).Do()
+	op, err := d.service.Images.Insert(project, gce_image).Do()
 	if err != nil {
 		errCh <- err
 	} else {
 		go func() {
-			err = waitForState(errCh, "DONE", d.refreshGlobalOp(op))
+			err = waitForState(errCh, "DONE", d.refreshGlobalOp(project, op))
 			if err != nil {
 				close(imageCh)
 				errCh <- err
 				return
 			}
 			var image *Image
-			image, err = d.GetImageFromProject(d.projectId, name, false)
+			image, err = d.GetImageFromProject(project, name, false)
 			if err != nil {
 				close(imageCh)
 				errCh <- err
@@ -209,14 +209,14 @@ func (d *driverGCE) CreateImage(name, description, family, zone, disk string, im
 	return imageCh, errCh
 }
 
-func (d *driverGCE) DeleteImage(name string) <-chan error {
+func (d *driverGCE) DeleteImage(project, name string) <-chan error {
 	errCh := make(chan error, 1)
-	op, err := d.service.Images.Delete(d.projectId, name).Do()
+	op, err := d.service.Images.Delete(project, name).Do()
 	if err != nil {
 		errCh <- err
 	} else {
 		go func() {
-			_ = waitForState(errCh, "DONE", d.refreshGlobalOp(op))
+			_ = waitForState(errCh, "DONE", d.refreshGlobalOp(project, op))
 		}()
 
 	}
@@ -379,8 +379,8 @@ func (d *driverGCE) GetSerialPortOutput(zone, name string) (string, error) {
 	return output.Contents, nil
 }
 
-func (d *driverGCE) ImageExists(name string) bool {
-	_, err := d.GetImageFromProject(d.projectId, name, false)
+func (d *driverGCE) ImageExists(project, name string) bool {
+	_, err := d.GetImageFromProject(project, name, false)
 	// The API may return an error for reasons other than the image not
 	// existing, but this heuristic is sufficient for now.
 	return err == nil
@@ -685,9 +685,9 @@ func (d *driverGCE) refreshInstanceState(zone, name string) stateRefreshFunc {
 	}
 }
 
-func (d *driverGCE) refreshGlobalOp(op *compute.Operation) stateRefreshFunc {
+func (d *driverGCE) refreshGlobalOp(project string, op *compute.Operation) stateRefreshFunc {
 	return func() (string, error) {
-		newOp, err := d.service.GlobalOperations.Get(d.projectId, op.Name).Do()
+		newOp, err := d.service.GlobalOperations.Get(project, op.Name).Do()
 		if err != nil {
 			return "", err
 		}

--- a/builder/googlecompute/step_check_existing_image.go
+++ b/builder/googlecompute/step_check_existing_image.go
@@ -19,10 +19,10 @@ func (s *StepCheckExistingImage) Run(ctx context.Context, state multistep.StateB
 	ui := state.Get("ui").(packersdk.Ui)
 
 	ui.Say("Checking image does not exist...")
-	c.imageAlreadyExists = d.ImageExists(c.ImageName)
+	c.imageAlreadyExists = d.ImageExists(c.ImageProjectId, c.ImageName)
 	if !c.PackerForce && c.imageAlreadyExists {
-		err := fmt.Errorf("Image %s already exists.\n"+
-			"Use the force flag to delete it prior to building.", c.ImageName)
+		err := fmt.Errorf("Image %s already exists in project %s.\n"+
+			"Use the force flag to delete it prior to building.", c.ImageName, c.ImageProjectId)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -31,7 +31,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	if config.PackerForce && config.imageAlreadyExists {
 		ui.Say("Deleting previous image...")
 
-		errCh := driver.DeleteImage(config.ImageName)
+		errCh := driver.DeleteImage(config.ImageProjectId, config.ImageName)
 		err := <-errCh
 		if err != nil {
 			err := fmt.Errorf("Error deleting image: %s", err)
@@ -44,7 +44,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	ui.Say("Creating image...")
 
 	imageCh, errCh := driver.CreateImage(
-		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
+		config.ImageProjectId, config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
 		config.DiskName, config.ImageLabels, config.ImageLicenses, config.ImageEncryptionKey.ComputeType(),
 		config.ImageStorageLocations)
 	var err error
@@ -55,7 +55,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	if err != nil {
-		err := fmt.Errorf("Error waiting for image: %s", err)
+		err := fmt.Errorf("Error waiting for image: %s in", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -86,6 +86,8 @@
 
 - `image_licenses` ([]string) - Licenses to apply to the created image.
 
+- `image_project_id` (string) - The project ID to push the build image into. Defaults to project_id.
+
 - `image_storage_locations` ([]string) - Storage location, either regional or multi-regional, where snapshot
   content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional
   location.

--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -358,6 +358,49 @@ build {
 </Tab>
 </Tabs>
 
+### Separate Image Project Example
+
+This is an example of using the `image_project_id` configuration option to create
+the generated image in a different GCP project than the one used to create the virtual machine. Make sure that Packer has permission in the target project to manage images, the `Compute Storage Admin` role will grant the desired permissions.
+
+<Tabs>
+<Tab heading="JSON">
+
+```json
+{
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "my project",
+      "image_project_id": "my image target project",
+      "source_image": "debian-9-stretch-v20200805",
+      "ssh_username": "packer",
+      "zone": "us-central1-a"
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "googlecompute" "basic-example" {
+  project_id = "my project"
+  image_project_id = "my image target project"
+  source_image = "debian-9-stretch-v20200805"
+  ssh_username = "packer"
+  zone = "us-central1-a"
+}
+
+build {
+  sources = ["sources.googlecompute.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
+
 ## Configuration Reference
 
 Configuration options are organized below into two categories: required and


### PR DESCRIPTION
This PR creates an `image_project_id` configuration option (which defaults to `project_id`) and allows defining a different project that an image should be created in.

I'm not sure of a good way to write tests for this addition, but I am using this version of the plugin locally and confirm it works as intended. 
 
Closes #30


