### PR TITLE
Use user-configured Service Account for public key import when running in GCE

### DIFF
--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -20,7 +20,7 @@ type StepImportOSLoginSSHKey struct {
 	Debug         bool
 	TokeninfoFunc func(context.Context) (*oauth2.Tokeninfo, error)
 	accountEmail  string
-	GCEUserFunc   func() (string)
+	GCEUserFunc   func() string
 }
 
 // Run executes the Packer build step that generates SSH key pairs.
@@ -73,7 +73,6 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 
 		s.accountEmail = info.Email
 	}
-
 
 	if s.accountEmail == "" {
 		err := fmt.Errorf("All options for deriving the OSLogin user have been exhausted")

--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -43,7 +43,13 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 	// Are we running packer on a GCE ?
 	s.accountEmail = getGCEUser()
 
-	if s.TokeninfoFunc == nil && s.accountEmail == "" {
+	// A configured account overrides the GCE accountEmail
+	if config.account != nil {
+		s.accountEmail = config.account.jwt.Email
+	}
+
+	// A configured token overrides GCE and account file
+	if s.TokeninfoFunc == nil {
 		s.TokeninfoFunc = tokeninfo
 	}
 
@@ -53,9 +59,6 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 	sha256sum := sha256.Sum256(config.Comm.SSHPublicKey)
 	state.Put("ssh_key_public_sha256", hex.EncodeToString(sha256sum[:]))
 
-	if config.account != nil && s.accountEmail == "" {
-		s.accountEmail = config.account.jwt.Email
-	}
 
 	if s.accountEmail == "" {
 		info, err := s.TokeninfoFunc(ctx)

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -130,7 +130,7 @@ func TestStepImportOSLoginSSHKey_withGCEAndNoAccount(t *testing.T) {
 	state := testState(t)
 	fakeGCEEmail := "testing@packer.io"
 	step := &StepImportOSLoginSSHKey{
-		GCEUserFunc: func() (string) {
+		GCEUserFunc: func() string {
 			return fakeGCEEmail
 		},
 	}

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -165,7 +165,7 @@ func TestStepImportOSLoginSSHKey_withGCEAndAccount(t *testing.T) {
 	fakeGCEEmail := "testing@packer.io"
 	fakeAccountEmail := "raffi-compute@developer.gserviceaccount.com"
 	step := &StepImportOSLoginSSHKey{
-		GCEUserFunc: func() (string) {
+		GCEUserFunc: func() string {
 			return fakeGCEEmail
 		},
 	}

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -92,19 +92,18 @@ func TestStepImportOSLoginSSHKey_withAccountFile(t *testing.T) {
 	}
 }
 
-func TestStepImportOSLoginSSHKey_withAccountFileAndToken(t *testing.T) {
-	// default teststate contains an account file
+func TestStepImportOSLoginSSHKey_withNoAccountFile(t *testing.T) {
 	state := testState(t)
-	fakeAccountEmailToken := "testing@packer.io"
-	fakeAccountEmailAccount := "raffi-compute@developer.gserviceaccount.com"
+	fakeAccountEmail := "testing@packer.io"
 	step := &StepImportOSLoginSSHKey{
 		TokeninfoFunc: func(ctx context.Context) (*oauth2.Tokeninfo, error) {
-			return &oauth2.Tokeninfo{Email: fakeAccountEmailToken}, nil
+			return &oauth2.Tokeninfo{Email: fakeAccountEmail}, nil
 		},
 	}
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
+	config.account = nil
 	config.UseOSLogin = true
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 
@@ -112,8 +111,8 @@ func TestStepImportOSLoginSSHKey_withAccountFileAndToken(t *testing.T) {
 		t.Fatalf("bad action: %#v", action)
 	}
 
-	if step.accountEmail != fakeAccountEmailToken {
-		t.Fatalf("expected accountEmail to be %q but got %q", fakeAccountEmailToken, step.accountEmail)
+	if step.accountEmail != fakeAccountEmail {
+		t.Fatalf("expected accountEmail to be %q but got %q", fakeAccountEmail, step.accountEmail)
 	}
 
 	pubKey, ok := state.GetOk("ssh_key_public_sha256")
@@ -127,18 +126,52 @@ func TestStepImportOSLoginSSHKey_withAccountFileAndToken(t *testing.T) {
 	}
 }
 
-func TestStepImportOSLoginSSHKey_withNoAccountFile(t *testing.T) {
+func TestStepImportOSLoginSSHKey_withGCEAndNoAccount(t *testing.T) {
 	state := testState(t)
-	fakeAccountEmail := "testing@packer.io"
+	fakeGCEEmail := "testing@packer.io"
 	step := &StepImportOSLoginSSHKey{
-		TokeninfoFunc: func(ctx context.Context) (*oauth2.Tokeninfo, error) {
-			return &oauth2.Tokeninfo{Email: fakeAccountEmail}, nil
+		GCEUserFunc: func() (string) {
+			return fakeGCEEmail
 		},
 	}
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
 	config.account = nil
+	config.UseOSLogin = true
+	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
+
+	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+		t.Fatalf("bad action: %#v", action)
+	}
+
+	if step.accountEmail != fakeGCEEmail {
+		t.Fatalf("expected accountEmail to be %q but got %q", fakeGCEEmail, step.accountEmail)
+	}
+
+	pubKey, ok := state.GetOk("ssh_key_public_sha256")
+	if !ok {
+		t.Fatal("expected to see a public key")
+	}
+
+	sha256sum := sha256.Sum256(config.Comm.SSHPublicKey)
+	if pubKey != hex.EncodeToString(sha256sum[:]) {
+		t.Errorf("expected to see a matching public key, but got %q", pubKey)
+	}
+}
+
+func TestStepImportOSLoginSSHKey_withGCEAndAccount(t *testing.T) {
+	state := testState(t)
+	fakeGCEEmail := "testing@packer.io"
+	fakeAccountEmail := "raffi-compute@developer.gserviceaccount.com"
+	step := &StepImportOSLoginSSHKey{
+		GCEUserFunc: func() (string) {
+			return fakeGCEEmail
+		},
+	}
+	defer step.Cleanup(state)
+
+	config := state.Get("config").(*Config)
 	config.UseOSLogin = true
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 


### PR DESCRIPTION
When running on a Compute Engine instance, `StepImportOSLoginSSHKey` uses the account name from the GCE instance even if a different service account is configured. This can cause Packer to authenticate to Google API using the configured service account but attempt to create an SSH key for the GCE service account, resulting in an error:

    googleapi: Error 403: End user credentials must match the user specified in the request

This changes the behavior and uses the GCE service account only if there is no service account in the configuration.

Closes #5 


