### PR TITLE
Treat ERROR 4047 as retryable.

### DIFF
--- a/builder/googlecompute/step_start_tunnel.go
+++ b/builder/googlecompute/step_start_tunnel.go
@@ -100,15 +100,14 @@ func RunTunnelCommand(cmd *exec.Cmd, timeout int) error {
 
 		if strings.Contains(lineStderr, "ERROR") {
 			// 4033: Either you don't have permission to access the instance,
-			// the instance doesn't exist, or the instance is stopped.
-			// The two sub-errors we may see while the permissions settle are
-			// "not authorized" and "failed to connect to backend," but after
-			// about a minute of retries this goes away and we're able to
-			// connect.
+			// the instance doesn't exist, or the instance is stopped. The two
+			// sub-errors we may see while the permissions settle are "not
+			// authorized" and "failed to connect to backend," but after about a
+			// minute of retries this goes away and we're able to connect.
 			// 4003: "failed to connect to backend". Network blip.
-			// 4047: "Either the instance doesn't exist, or the instance
-			// is stopped. Ensure that the VM is powered on and has 
-			// completed its startup" — Let's wait a little more in this case.
+			// 4047: "Either the instance doesn't exist, or the instance is
+			// stopped. Ensure that the VM is powered on and has completed its
+			// startup" — Let's wait a little more in this case.
 			if strings.Contains(lineStderr, "4033") || strings.Contains(lineStderr, "4003") || strings.Contains(lineStderr, "4047") {
 				return RetryableTunnelError{lineStderr}
 			} else {


### PR DESCRIPTION
Treat ERROR 4047 as retryable.

There is a race condition when creating an iap tunnel to the compute instance (vm).

The code creates a vm and waits until the state of the vm is set to RUNNING. It then tries to create an iap tunnel to the vm in a loop with a timeout.

There is a period of time after the vm gets into the RUNNING state and one can actually create the tunnel. Therefore, the code tries to ignore some errors returned by the gcloud tool and retry the tunnel creation.

As of recently, we see first ERROR 4033 followed by ERROR 4047. The first one is treated as retryable, however, the second one is not. This ends all attempts to create the tunnel and thus ends the image creation with an error.

This change fixes the issue by treating ERROR 4047 returned by the gcloud tool as retryable.