### PR TITLE
Allow choosing nic-type on instance creation #28

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -120,6 +120,8 @@ type Config struct {
 	ImageLabels map[string]string `mapstructure:"image_labels" required:"false"`
 	// Licenses to apply to the created image.
 	ImageLicenses []string `mapstructure:"image_licenses" required:"false"`
+	// Guest OS features to apply to the created image.
+	ImageGuestOsFeatures []string `mapstructure:"image_guest_os_features" required:"false"`
 	// Storage location, either regional or multi-regional, where snapshot
 	// content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional
 	// location.

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -93,6 +93,7 @@ type FlatConfig struct {
 	ImageFamily                  *string                    `mapstructure:"image_family" required:"false" cty:"image_family" hcl:"image_family"`
 	ImageLabels                  map[string]string          `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
 	ImageLicenses                []string                   `mapstructure:"image_licenses" required:"false" cty:"image_licenses" hcl:"image_licenses"`
+	ImageGuestOsFeatures         []string                   `mapstructure:"image_guest_os_features" required:"false" cty:"image_guest_os_features" hcl:"image_guest_os_features"`
 	ImageStorageLocations        []string                   `mapstructure:"image_storage_locations" required:"false" cty:"image_storage_locations" hcl:"image_storage_locations"`
 	InstanceName                 *string                    `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	Labels                       map[string]string          `mapstructure:"labels" required:"false" cty:"labels" hcl:"labels"`
@@ -219,6 +220,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_family":                    &hcldec.AttrSpec{Name: "image_family", Type: cty.String, Required: false},
 		"image_labels":                    &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},
 		"image_licenses":                  &hcldec.AttrSpec{Name: "image_licenses", Type: cty.List(cty.String), Required: false},
+		"image_guest_os_features":         &hcldec.AttrSpec{Name: "image_guest_os_features", Type: cty.List(cty.String), Required: false},
 		"image_storage_locations":         &hcldec.AttrSpec{Name: "image_storage_locations", Type: cty.List(cty.String), Required: false},
 		"instance_name":                   &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"labels":                          &hcldec.AttrSpec{Name: "labels", Type: cty.Map(cty.String), Required: false},

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -596,6 +596,9 @@ func testConfig(t *testing.T) (config map[string]interface{}, tempAccountFile st
 		"image_licenses": []string{
 			"test-license",
 		},
+		"image_guest_os_features": []string{
+			"UEFI_COMPATIBLE",
+		},
 		"image_storage_locations": []string{
 			"us-east1",
 		},

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -14,7 +14,7 @@ import (
 type Driver interface {
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
+	CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_guest_os_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
 	DeleteImage(name string) <-chan error

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -170,9 +170,9 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 
 func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_guest_os_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
 
-	imageFeatures := make([]*compute.GuestOsFeature, len(image_guest_os_features))
+	image_features := make([]*compute.GuestOsFeature, 0, len(image_guest_os_features))
 	for _, v := range image_guest_os_features {
-		imageFeatures = append(imageFeatures, &compute.GuestOsFeature{
+		image_features = append(image_features, &compute.GuestOsFeature{
 			Type: v,
 		})
 	}
@@ -182,7 +182,7 @@ func (d *driverGCE) CreateImage(name, description, family, zone, disk string, im
 		Family:             family,
 		Labels:             image_labels,
 		Licenses:           image_licenses,
-		GuestOsFeatures:    imageFeatures,
+		GuestOsFeatures:    image_features,
 		ImageEncryptionKey: image_encryption_key,
 		SourceDisk:         fmt.Sprintf("%sprojects/%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:         "RAW",

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -168,13 +168,21 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 	}, nil
 }
 
-func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
+func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_guest_os_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
+
+	imageFeatures := make([]*compute.GuestOsFeature, len(image_guest_os_features))
+	for _, v := range image_guest_os_features {
+		imageFeatures = append(imageFeatures, &compute.GuestOsFeature{
+			Type: v,
+		})
+	}
 	gce_image := &compute.Image{
 		Description:        description,
 		Name:               name,
 		Family:             family,
 		Labels:             image_labels,
 		Licenses:           image_licenses,
+		GuestOsFeatures:    imageFeatures,
 		ImageEncryptionKey: image_encryption_key,
 		SourceDisk:         fmt.Sprintf("%sprojects/%s/zones/%s/disks/%s", d.service.BasePath, d.projectId, zone, disk),
 		SourceType:         "RAW",

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -119,7 +119,7 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 	if d.CreateImageResultSizeGb == 0 {
 		d.CreateImageResultSizeGb = 10
 	}
-	imageFeatures := make([]*compute.GuestOsFeature, len(image_features))
+	imageFeatures := make([]*compute.GuestOsFeature, 0, len(image_features))
 	for _, v := range image_features {
 		imageFeatures = append(imageFeatures, &compute.GuestOsFeature{
 			Type: v,
@@ -129,9 +129,9 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 	if resultCh == nil {
 		ch := make(chan *Image, 1)
 		ch <- &Image{
+			GuestOsFeatures: imageFeatures,
 			Labels:          d.CreateImageLabels,
 			Licenses:        d.CreateImageLicenses,
-			GuestOsFeatures: imageFeatures,
 			Name:            name,
 			ProjectId:       d.CreateImageResultProjectId,
 			SelfLink:        d.CreateImageResultSelfLink,

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -45,8 +45,8 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 	imageCh, errCh := driver.CreateImage(
 		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
-		config.DiskName, config.ImageLabels, config.ImageLicenses, config.ImageEncryptionKey.ComputeType(),
-		config.ImageStorageLocations)
+		config.DiskName, config.ImageLabels, config.ImageLicenses, config.ImageGuestOsFeatures,
+		config.ImageEncryptionKey.ComputeType(), config.ImageStorageLocations)
 	var err error
 	select {
 	case err = <-errCh:

--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -24,6 +24,9 @@ func TestStepCreateImage(t *testing.T) {
 	// These are the values of the image the driver will return.
 	d.CreateImageResultProjectId = "test-project"
 	d.CreateImageResultSizeGb = 100
+	d.CreateImageFeatures = []string{
+		"UEFI_COMPATIBLE",
+	}
 
 	// run the step
 	action := step.Run(context.Background(), state)
@@ -38,6 +41,7 @@ func TestStepCreateImage(t *testing.T) {
 	assert.Equal(t, image.Name, c.ImageName, "Created image does not match config name.")
 	assert.Equal(t, image.ProjectId, d.CreateImageResultProjectId, "Created image project does not match driver project.")
 	assert.Equal(t, image.SizeGb, d.CreateImageResultSizeGb, "Created image size does not match the size returned by the driver.")
+	assert.Equal(t, len(image.GuestOsFeatures), len(d.CreateImageFeatures), "Created image features does not match config features.")
 
 	// Verify proper args passed to driver.CreateImage.
 	assert.Equal(t, d.CreateImageName, c.ImageName, "Incorrect image name passed to driver.")

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -86,6 +86,8 @@
 
 - `image_licenses` ([]string) - Licenses to apply to the created image.
 
+- `image_guest_os_features` ([]string) - Guest OS features to apply to the created image.
+
 - `image_storage_locations` ([]string) - Storage location, either regional or multi-regional, where snapshot
   content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional
   location.


### PR DESCRIPTION
*Allow choosing nic-type on instance creation #28*

Added a new configuration option: *image_guest_os_features*
This parameter enables one or more features for VM instances that use the image for their boot disks.
See https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#guest-os-features
for descriptions of the supported features:
* GUEST_OS_FEATURES: GVNIC
* MULTI_IP_SUBNET
* SEV_CAPABLE
* UEFI_COMPATIBLE
* VIRTIO_SCSI_MULTIQUEUE, WINDOWS.

Closes #28 

