### PR TITLE
[WIP] Add DiskEncryptionKey to support CMEK on boot disks

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -69,6 +69,8 @@ type Config struct {
 	// Type of disk used to back your instance, like pd-ssd or pd-standard.
 	// Defaults to pd-standard.
 	DiskType string `mapstructure:"disk_type" required:"false"`
+	// The self_link of the encryption key that is stored in Google Cloud KMS to encrypt this disk
+	DiskEncryptionKey string `mapstructure:"disk_encryption_key" required:"false"`
 	// Create a Shielded VM image with Secure Boot enabled. It helps ensure that
 	// the system only runs authentic software by verifying the digital signature
 	// of all boot components, and halting the boot process if signature verification

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -82,6 +82,7 @@ type InstanceConfig struct {
 	DisableDefaultServiceAccount bool
 	DiskSizeGb                   int64
 	DiskType                     string
+	DiskEncryptionKey            string
 	EnableSecureBoot             bool
 	EnableVtpm                   bool
 	EnableIntegrityMonitoring    bool

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -171,6 +171,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		DisableDefaultServiceAccount: c.DisableDefaultServiceAccount,
 		DiskSizeGb:                   c.DiskSizeGb,
 		DiskType:                     c.DiskType,
+		DiskEncryptionKey:            c.DiskEncryptionKey,
 		EnableSecureBoot:             c.EnableSecureBoot,
 		EnableVtpm:                   c.EnableVtpm,
 		EnableIntegrityMonitoring:    c.EnableIntegrityMonitoring,


### PR DESCRIPTION
This PR adds DiskEncryptionKey to allow a CMEK key to be used for the boot disk of the instance created during the build process.

Tests still need to be written

Closes #43 
cc: @kamaltherocky
