### PR TITLE
Pass DiskName when creating instance

### DIFF
--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -80,6 +80,7 @@ type InstanceConfig struct {
 	Address                      string
 	Description                  string
 	DisableDefaultServiceAccount bool
+	DiskName                     string
 	DiskSizeGb                   int64
 	DiskType                     string
 	EnableSecureBoot             bool

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -473,6 +473,7 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 				AutoDelete: false,
 				InitializeParams: &compute.AttachedDiskInitializeParams{
 					SourceImage: c.Image.SelfLink,
+					DiskName:    c.DiskName,
 					DiskSizeGb:  c.DiskSizeGb,
 					DiskType:    fmt.Sprintf("zones/%s/diskTypes/%s", zone.Name, c.DiskType),
 				},

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -169,6 +169,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		Address:                      c.Address,
 		Description:                  "New instance created by Packer",
 		DisableDefaultServiceAccount: c.DisableDefaultServiceAccount,
+		DiskName:                     c.DiskName,
 		DiskSizeGb:                   c.DiskSizeGb,
 		DiskType:                     c.DiskType,
 		EnableSecureBoot:             c.EnableSecureBoot,


### PR DESCRIPTION
`DiskName` should be passed to `Instance.Disks[0].InitializeParams.AttachedDiskInitializeParams.DiskName`

Closes #50 


