### PR TITLE
Ensure OS Login API calls are using the correct Identities

### DIFF
--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -1,10 +1,12 @@
 package googlecompute
 
 import (
+	"context"
 	"crypto/rsa"
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
+	goauth2 "google.golang.org/api/oauth2/v2"
 	oslogin "google.golang.org/api/oslogin/v1"
 )
 
@@ -72,6 +74,9 @@ type Driver interface {
 
 	// Add to the instance metadata for the existing instance
 	AddToInstanceMetadata(zone string, name string, metadata map[string]string) error
+
+	// Get tokenfine from https://oauth2.googleapis.com/tokeninfo
+	GetTokenInfo(ctx context.Context) (*goauth2.Tokeninfo, error)
 }
 
 type InstanceConfig struct {

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -1,12 +1,10 @@
 package googlecompute
 
 import (
-	"context"
 	"crypto/rsa"
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
-	goauth2 "google.golang.org/api/oauth2/v2"
 	oslogin "google.golang.org/api/oslogin/v1"
 )
 
@@ -74,9 +72,6 @@ type Driver interface {
 
 	// Add to the instance metadata for the existing instance
 	AddToInstanceMetadata(zone string, name string, metadata map[string]string) error
-
-	// Get tokenfine from https://oauth2.googleapis.com/tokeninfo
-	GetTokenInfo(ctx context.Context) (*goauth2.Tokeninfo, error)
 }
 
 type InstanceConfig struct {

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	compute "google.golang.org/api/compute/v1"
-	goauth2 "google.golang.org/api/oauth2/v2"
 	"google.golang.org/api/option"
 	oslogin "google.golang.org/api/oslogin/v1"
 
@@ -34,7 +33,6 @@ type driverGCE struct {
 	projectId      string
 	service        *compute.Service
 	osLoginService *oslogin.Service
-	oauth2Service  *goauth2.Service
 	ui             packersdk.Ui
 }
 
@@ -159,23 +157,12 @@ func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 		return nil, err
 	}
 
-	log.Printf("[INFO] Instantiating OAuth client...")
-	oauth2Service, err := goauth2.NewService(context.TODO(), opts...)
-	if err != nil {
-		return nil, err
-	}
-
 	return &driverGCE{
 		projectId:      config.ProjectId,
 		service:        service,
 		osLoginService: osLoginService,
-		oauth2Service:  oauth2Service,
 		ui:             config.Ui,
 	}, nil
-}
-
-func (d *driverGCE) GetTokenInfo(ctx context.Context) (*goauth2.Tokeninfo, error) {
-	return d.oauth2Service.Tokeninfo().Context(ctx).Do()
 }
 
 func (d *driverGCE) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {

--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -5,22 +5,15 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"log"
-	"net/http"
-	"time"
 
-	metadata "cloud.google.com/go/compute/metadata"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-	"google.golang.org/api/oauth2/v2"
 )
 
 // StepImportOSLoginSSHKey imports a temporary SSH key pair into a GCE login profile.
 type StepImportOSLoginSSHKey struct {
-	Debug         bool
-	TokeninfoFunc func(context.Context) (*oauth2.Tokeninfo, error)
-	accountEmail  string
-	GCEUserFunc   func() string
+	Debug        bool
+	accountEmail string
 }
 
 // Run executes the Packer build step that generates SSH key pairs.
@@ -51,19 +44,8 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 		s.accountEmail = config.account.jwt.Email
 	}
 
-	if s.GCEUserFunc == nil {
-		s.GCEUserFunc = getGCEUser
-	}
 	if s.accountEmail == "" {
-		s.accountEmail = s.GCEUserFunc()
-	}
-
-	if s.TokeninfoFunc == nil && s.accountEmail == "" {
-		s.TokeninfoFunc = tokeninfo
-	}
-
-	if s.accountEmail == "" {
-		info, err := s.TokeninfoFunc(ctx)
+		info, err := driver.GetTokenInfo(ctx)
 		if err != nil {
 			err := fmt.Errorf("Error obtaining token information needed for OSLogin: %s", err)
 			state.Put("error", err)
@@ -138,39 +120,4 @@ func (s *StepImportOSLoginSSHKey) Cleanup(state multistep.StateBag) {
 	}
 
 	ui.Message("SSH public key for OSLogin has been deleted!")
-}
-
-func tokeninfo(ctx context.Context) (*oauth2.Tokeninfo, error) {
-	svc, err := oauth2.NewService(ctx)
-	if err != nil {
-		err := fmt.Errorf("Error initializing oauth service needed for OSLogin: %s", err)
-		return nil, err
-	}
-
-	return svc.Tokeninfo().Context(ctx).Do()
-}
-
-// getGCEUser determines if we're running packer on a GCE, and if we are, gets the associated service account email for subsequent use with OSLogin.
-// There are cases where we are running on a GCE, but the GCP metadata server isn't accessible. GitLab docker-engine runners are an edge case example of this.
-// It makes little sense to run packer on GCP in this way, however, we defensively timeout in those cases, rather than abort.
-func getGCEUser() string {
-
-	metadataCheckTimeout := 5 * time.Second
-	metadataCheckChl := make(chan string, 1)
-
-	go func() {
-		if metadata.OnGCE() {
-			GCEUser, _ := metadata.NewClient(&http.Client{}).Email("")
-			metadataCheckChl <- GCEUser
-		}
-	}()
-
-	select {
-	case thisGCEUser := <-metadataCheckChl:
-		log.Printf("[INFO] OSLogin: GCE service account %s will be used for identity", thisGCEUser)
-		return thisGCEUser
-	case <-time.After(metadataCheckTimeout):
-		log.Printf("[INFO] OSLogin: Could not derive a GCE service account from google metadata server after %s", metadataCheckTimeout)
-		return ""
-	}
 }

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -96,7 +96,7 @@ func TestStepImportOSLoginSSHKey_withNoAccountFile(t *testing.T) {
 	state := testState(t)
 	fakeAccountEmail := "testing@packer.io"
 	step := &StepImportOSLoginSSHKey{
-		TokeninfoFunc: func(ctx context.Context, impersonatedsa string) (*oauth2.Tokeninfo, error) {
+		TokeninfoFunc: func(_ context.Context, _ string) (*oauth2.Tokeninfo, error) {
 			return &oauth2.Tokeninfo{Email: fakeAccountEmail}, nil
 		},
 	}

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
-	"google.golang.org/api/oauth2/v2"
 )
 
 func TestStepImportOSLoginSSHKey_impl(t *testing.T) {
@@ -95,83 +94,11 @@ func TestStepImportOSLoginSSHKey_withAccountFile(t *testing.T) {
 func TestStepImportOSLoginSSHKey_withNoAccountFile(t *testing.T) {
 	state := testState(t)
 	fakeAccountEmail := "testing@packer.io"
-	step := &StepImportOSLoginSSHKey{
-		TokeninfoFunc: func(ctx context.Context) (*oauth2.Tokeninfo, error) {
-			return &oauth2.Tokeninfo{Email: fakeAccountEmail}, nil
-		},
-	}
+	step := &StepImportOSLoginSSHKey{}
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
 	config.account = nil
-	config.UseOSLogin = true
-	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
-
-	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
-	}
-
-	if step.accountEmail != fakeAccountEmail {
-		t.Fatalf("expected accountEmail to be %q but got %q", fakeAccountEmail, step.accountEmail)
-	}
-
-	pubKey, ok := state.GetOk("ssh_key_public_sha256")
-	if !ok {
-		t.Fatal("expected to see a public key")
-	}
-
-	sha256sum := sha256.Sum256(config.Comm.SSHPublicKey)
-	if pubKey != hex.EncodeToString(sha256sum[:]) {
-		t.Errorf("expected to see a matching public key, but got %q", pubKey)
-	}
-}
-
-func TestStepImportOSLoginSSHKey_withGCEAndNoAccount(t *testing.T) {
-	state := testState(t)
-	fakeGCEEmail := "testing@packer.io"
-	step := &StepImportOSLoginSSHKey{
-		GCEUserFunc: func() string {
-			return fakeGCEEmail
-		},
-	}
-	defer step.Cleanup(state)
-
-	config := state.Get("config").(*Config)
-	config.account = nil
-	config.UseOSLogin = true
-	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
-
-	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
-	}
-
-	if step.accountEmail != fakeGCEEmail {
-		t.Fatalf("expected accountEmail to be %q but got %q", fakeGCEEmail, step.accountEmail)
-	}
-
-	pubKey, ok := state.GetOk("ssh_key_public_sha256")
-	if !ok {
-		t.Fatal("expected to see a public key")
-	}
-
-	sha256sum := sha256.Sum256(config.Comm.SSHPublicKey)
-	if pubKey != hex.EncodeToString(sha256sum[:]) {
-		t.Errorf("expected to see a matching public key, but got %q", pubKey)
-	}
-}
-
-func TestStepImportOSLoginSSHKey_withGCEAndAccount(t *testing.T) {
-	state := testState(t)
-	fakeGCEEmail := "testing@packer.io"
-	fakeAccountEmail := "raffi-compute@developer.gserviceaccount.com"
-	step := &StepImportOSLoginSSHKey{
-		GCEUserFunc: func() string {
-			return fakeGCEEmail
-		},
-	}
-	defer step.Cleanup(state)
-
-	config := state.Get("config").(*Config)
 	config.UseOSLogin = true
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 

--- a/post-processor/googlecompute-import/post-processor.go
+++ b/post-processor/googlecompute-import/post-processor.go
@@ -157,7 +157,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	}
 	p.config.ctx.Data = generatedData
 	var err error
-	var opts option.ClientOption
+	var opts []option.ClientOption
 	opts, err = googlecompute.NewClientOptionGoogle(p.config.account, p.config.VaultGCPOauthEngine, p.config.ImpersonateServiceAccount, p.config.AccessToken)
 	if err != nil {
 		return nil, false, false, err
@@ -267,8 +267,8 @@ func CreateShieldedVMStateConfig(imageGuestOsFeatures []string, imagePlatformKey
 	return shieldedVMStateConfig, nil
 }
 
-func UploadToBucket(opts option.ClientOption, ui packersdk.Ui, artifact packersdk.Artifact, bucket string, gcsObjectName string) (string, error) {
-	service, err := storage.NewService(context.TODO(), opts)
+func UploadToBucket(opts []option.ClientOption, ui packersdk.Ui, artifact packersdk.Artifact, bucket string, gcsObjectName string) (string, error) {
+	service, err := storage.NewService(context.TODO(), opts...)
 	if err != nil {
 		return "", err
 	}
@@ -303,8 +303,8 @@ func UploadToBucket(opts option.ClientOption, ui packersdk.Ui, artifact packersd
 	return storageObject.SelfLink, nil
 }
 
-func CreateGceImage(opts option.ClientOption, ui packersdk.Ui, project string, rawImageURL string, imageName string, imageDescription string, imageFamily string, imageLabels map[string]string, imageGuestOsFeatures []string, shieldedVMStateConfig *compute.InitialStateConfig, imageStorageLocations []string) (packersdk.Artifact, error) {
-	service, err := compute.NewService(context.TODO(), opts)
+func CreateGceImage(opts []option.ClientOption, ui packersdk.Ui, project string, rawImageURL string, imageName string, imageDescription string, imageFamily string, imageLabels map[string]string, imageGuestOsFeatures []string, shieldedVMStateConfig *compute.InitialStateConfig, imageStorageLocations []string) (packersdk.Artifact, error) {
+	service, err := compute.NewService(context.TODO(), opts...)
 
 	if err != nil {
 		return nil, err
@@ -360,8 +360,8 @@ func CreateGceImage(opts option.ClientOption, ui packersdk.Ui, project string, r
 	return &Artifact{paths: []string{op.TargetLink}}, nil
 }
 
-func DeleteFromBucket(opts option.ClientOption, ui packersdk.Ui, bucket string, gcsObjectName string) error {
-	service, err := storage.NewService(context.TODO(), opts)
+func DeleteFromBucket(opts []option.ClientOption, ui packersdk.Ui, bucket string, gcsObjectName string) error {
+	service, err := storage.NewService(context.TODO(), opts...)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes: #73

Can I get some help with the `driver_mock.go`?

This change fixes a bug where the OS Login email lookup doesn't work if service account impersonation is being used. 

The `tokeninfo` function at the bottom of  `builder/googlecompute/step_import_os_login_ssh_key.go` is initialised with incorrect ClientOption and won't work if you are impersonating.

Also, `getGCEUser` is broken with service account impersonation as it uses the metadata server of the instance/pod to get the email of the identity that is impersonating and not the impersonated identity.

I have reworked it to acquire the correct Access Token from NewClientOptionGoogle and then use it to make a call to get email from https://oauth2.googleapis.com/tokeninfo

@azr @SwampDragons 