### PR TITLE
Add rocky-linux-cloud to GCE public projects

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -266,6 +266,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"debian-cloud",
 		"rhel-cloud",
 		"rhel-sap-cloud",
+		"rocky-linux-cloud",
 		"suse-cloud",
 		"suse-sap-cloud",
 		"suse-byos-cloud",


### PR DESCRIPTION
Add rocky-linux-cloud family to the public GCE projects array.

Closes #67

```
?   	github.com/hashicorp/packer-plugin-googlecompute	[no test files]
ok  	github.com/hashicorp/packer-plugin-googlecompute/builder/googlecompute	12.064s
ok  	github.com/hashicorp/packer-plugin-googlecompute/post-processor/googlecompute-export	0.656s
ok  	github.com/hashicorp/packer-plugin-googlecompute/post-processor/googlecompute-import	0.426s
?   	github.com/hashicorp/packer-plugin-googlecompute/version	[no test files]
```