### PR TITLE
Add support for fedora-cloud public image project

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -264,6 +264,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"cos-cloud",
 		"coreos-cloud",
 		"debian-cloud",
+		"fedora-cloud",
 		"rhel-cloud",
 		"rhel-sap-cloud",
 		"rocky-linux-cloud",


### PR DESCRIPTION
### Summary
Currently errors if you try to select a `fedora-cloud` image, this change will add the `fedora-cloud` project to the list of projects to be searched;

**Plugin and Packer version**
packer --version 1.7.8
hashicorp/packer-plugin-googlecompute 1.0.9

```
--> googlecompute.packer: Error getting source image for instance creation: Could not find image, fedora-cloud-35, in projects, [centos-cloud cos-cloud coreos-cloud debian-cloud rhel-cloud rhel-sap-cloud suse-cloud suse-sap-cloud suse-byos-cloud ubuntu-os-cloud windows-cloud windows-sql-cloud gce-nvme google-containers opensuse-cloud]: 16 error(s) occurred:

* googleapi: Error 404: The resource 'projects/centos-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/cos-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/coreos-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/debian-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/rhel-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/rhel-sap-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/suse-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/suse-sap-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/suse-byos-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/ubuntu-os-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/windows-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/windows-sql-cloud/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/gce-nvme/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/google-containers/global/images/family/fedora-cloud-35' was not found, notFound
* googleapi: Error 404: The resource 'projects/opensuse-cloud/global/images/family/fedora-cloud-35' was not found, notFound
```

Searching gcloud confirms that project is valid and images are available.
```
$ gcloud compute images list --filter=fedora-cloud
NAME                                 PROJECT       FAMILY           DEPRECATED  STATUS
fedora-cloud-base-gcp-33-1-2-x86-64  fedora-cloud  fedora-cloud-33              READY
fedora-cloud-base-gcp-34-1-2-x86-64  fedora-cloud  fedora-cloud-34              READY
fedora-cloud-base-gcp-35-1-2-x86-64  fedora-cloud  fedora-cloud-35              READY
```