### PR TITLE
Migrate to new Google Cloud impersonation API

### DIFF
--- a/builder/googlecompute/builder.go
+++ b/builder/googlecompute/builder.go
@@ -49,6 +49,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		Account:                       b.config.account,
 		AccessToken:                   b.config.AccessToken,
 		ImpersonateServiceAccountName: b.config.ImpersonateServiceAccount,
+		Scopes:                        b.config.Scopes,
 		VaultOauthEngineName:          b.config.VaultGCPOauthEngine,
 	}
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -507,7 +507,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 			errs, errors.New("a project_id must be specified"))
 	}
 
-	if c.Scopes == nil {
+	if len(c.Scopes) == 0 {
 		c.Scopes = []string{
 			"https://www.googleapis.com/auth/userinfo.email",
 			"https://www.googleapis.com/auth/compute",

--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -145,7 +145,7 @@ func (s *StepImportOSLoginSSHKey) Cleanup(state multistep.StateBag) {
 func tokeninfo(ctx context.Context, config *Config) (*oauth2.Tokeninfo, error) {
 	var err error
 	var opts []option.ClientOption
-	opts, err = NewClientOptionGoogle(config.account, config.VaultGCPOauthEngine, config.ImpersonateServiceAccount, config.AccessToken)
+	opts, err = NewClientOptionGoogle(config.account, config.VaultGCPOauthEngine, config.ImpersonateServiceAccount, config.AccessToken, config.Scopes)
 	if err != nil {
 		return nil, err
 	}

--- a/builder/googlecompute/step_wait_startup_script.go
+++ b/builder/googlecompute/step_wait_startup_script.go
@@ -37,22 +37,24 @@ func (s *StepWaitStartupScript) Run(ctx context.Context, state multistep.StateBa
 			instanceName, StartupScriptStatusKey)
 
 		if err != nil {
+			ui.Message(fmt.Sprintf("Metadatada %s on instance %s not available. Waiting...", StartupScriptStatusKey, instanceName))
 			err := fmt.Errorf("Error getting startup script status: %s", err)
 			return err
 		}
 
-		if status == StartupScriptStatusError {
-			err = errors.New("Startup script error.")
-			return err
-		}
+		switch status {
+		case StartupScriptStatusError:
+			ui.Message("Startup script in error. Waiting...")
+			return errors.New("Startup script error.")
 
-		done := status == StartupScriptStatusDone
-		if !done {
-			ui.Say("Startup script not finished yet. Waiting...")
+		case StartupScriptStatusDone:
+			ui.Message("Startup script successfully finished.")
+			return nil
+
+		default:
+			ui.Message("Startup script not finished yet. Waiting...")
 			return errors.New("Startup script not done.")
 		}
-
-		return nil
 	})
 
 	if err != nil {

--- a/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
+++ b/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
@@ -7,6 +7,15 @@
 
 - `impersonate_service_account` (string) - This allows service account impersonation as per the [docs](https://cloud.google.com/iam/docs/impersonating-service-accounts).
 
+- `scopes` ([]string) - The service account scopes for launched exporter post-processor instance.
+  Defaults to:
+  
+  ```json
+  [
+    "https://www.googleapis.com/auth/cloud-platform"
+  ]
+  ```
+
 - `disk_size` (int64) - The size of the export instances disk.
   The disk is unused for the export but a larger size will increase `pd-ssd` read speed.
   This defaults to `200`, which is 200GB.

--- a/docs-partials/post-processor/googlecompute-import/Config-not-required.mdx
+++ b/docs-partials/post-processor/googlecompute-import/Config-not-required.mdx
@@ -7,6 +7,15 @@
 
 - `impersonate_service_account` (string) - This allows service account impersonation as per the [docs](https://cloud.google.com/iam/docs/impersonating-service-accounts).
 
+- `scopes` ([]string) - The service account scopes for launched importer post-processor instance.
+  Defaults to:
+  
+  ```json
+  [
+    "https://www.googleapis.com/auth/cloud-platform"
+  ]
+  ```
+
 - `gcs_object_name` (string) - The name of the GCS object in `bucket` where
   the RAW disk image will be copied for import. This is treated as a
   [template engine](/docs/templates/legacy_json_templates/engine). Therefore, you

--- a/post-processor/googlecompute-export/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-export/post-processor.hcl2spec.go
@@ -21,6 +21,7 @@ type FlatConfig struct {
 	AccessToken               *string           `mapstructure:"access_token" required:"false" cty:"access_token" hcl:"access_token"`
 	AccountFile               *string           `mapstructure:"account_file" required:"false" cty:"account_file" hcl:"account_file"`
 	ImpersonateServiceAccount *string           `mapstructure:"impersonate_service_account" required:"false" cty:"impersonate_service_account" hcl:"impersonate_service_account"`
+	Scopes                    []string          `mapstructure:"scopes" required:"false" cty:"scopes" hcl:"scopes"`
 	DiskSizeGb                *int64            `mapstructure:"disk_size" cty:"disk_size" hcl:"disk_size"`
 	DiskType                  *string           `mapstructure:"disk_type" cty:"disk_type" hcl:"disk_type"`
 	MachineType               *string           `mapstructure:"machine_type" cty:"machine_type" hcl:"machine_type"`
@@ -55,6 +56,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"access_token":                &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"account_file":                &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
 		"impersonate_service_account": &hcldec.AttrSpec{Name: "impersonate_service_account", Type: cty.String, Required: false},
+		"scopes":                      &hcldec.AttrSpec{Name: "scopes", Type: cty.List(cty.String), Required: false},
 		"disk_size":                   &hcldec.AttrSpec{Name: "disk_size", Type: cty.Number, Required: false},
 		"disk_type":                   &hcldec.AttrSpec{Name: "disk_type", Type: cty.String, Required: false},
 		"machine_type":                &hcldec.AttrSpec{Name: "machine_type", Type: cty.String, Required: false},

--- a/post-processor/googlecompute-import/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-import/post-processor.hcl2spec.go
@@ -21,6 +21,7 @@ type FlatConfig struct {
 	AccessToken                *string           `mapstructure:"access_token" required:"false" cty:"access_token" hcl:"access_token"`
 	AccountFile                *string           `mapstructure:"account_file" required:"false" cty:"account_file" hcl:"account_file"`
 	ImpersonateServiceAccount  *string           `mapstructure:"impersonate_service_account" required:"false" cty:"impersonate_service_account" hcl:"impersonate_service_account"`
+	Scopes                     []string          `mapstructure:"scopes" required:"false" cty:"scopes" hcl:"scopes"`
 	ProjectId                  *string           `mapstructure:"project_id" required:"true" cty:"project_id" hcl:"project_id"`
 	IAP                        *bool             `mapstructure-to-hcl:",skip" cty:"iap" hcl:"iap"`
 	Bucket                     *string           `mapstructure:"bucket" required:"true" cty:"bucket" hcl:"bucket"`
@@ -62,6 +63,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"access_token":                  &hcldec.AttrSpec{Name: "access_token", Type: cty.String, Required: false},
 		"account_file":                  &hcldec.AttrSpec{Name: "account_file", Type: cty.String, Required: false},
 		"impersonate_service_account":   &hcldec.AttrSpec{Name: "impersonate_service_account", Type: cty.String, Required: false},
+		"scopes":                        &hcldec.AttrSpec{Name: "scopes", Type: cty.List(cty.String), Required: false},
 		"project_id":                    &hcldec.AttrSpec{Name: "project_id", Type: cty.String, Required: false},
 		"iap":                           &hcldec.AttrSpec{Name: "iap", Type: cty.Bool, Required: false},
 		"bucket":                        &hcldec.AttrSpec{Name: "bucket", Type: cty.String, Required: false},


### PR DESCRIPTION
I updated the code using the non-deprecated way of using Google Cloud IAM impersonation.

Despite my efforts, I've been unable to submit any relevant unit tests since this part of the code is tied to Google remote API (POST requests are performed).
I tried to invoke/create mocking objects without success.

As a result, I think that this should be tested with integration tests but it looks like nothing similar exists yet (it would probably be quite expensive to have a dedicated GCP project).

Nevertheless, I would be more than happy if someone could help me on that.
Hope my contribution will be helpful.

Closes #83 