### PR TITLE
adding ubuntu pro project

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -278,6 +278,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		// misc
 		"google-containers",
 		"opensuse-cloud",
+		"ubuntu-os-pro-cloud"
 	}
 	return d.GetImageFromProjects(projects, name, fromFamily)
 }


### PR DESCRIPTION
This adds the `ubuntu-os-pro-cloud` project to the list of projects in the [GetImage](https://github.com/hashicorp/packer-plugin-googlecompute/blob/main/builder/googlecompute/driver_gce.go#L257-L281) function.

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #87 

