### PR TITLE
fixed missing comma

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -278,7 +278,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		// misc
 		"google-containers",
 		"opensuse-cloud",
-		"ubuntu-os-pro-cloud"
+		"ubuntu-os-pro-cloud",
 	}
 	return d.GetImageFromProjects(projects, name, fromFamily)
 }


### PR DESCRIPTION
Added the missing comma on line 281 causing the following error on `go build`:
```bash
# github.com/hashicorp/packer-plugin-googlecompute/builder/googlecompute
builder/googlecompute/driver_gce.go:281:24: syntax error: unexpected newline, expecting comma or }
```

Should have validated before initial PR but fixed now... `go build` builds successfully. 
