### PR TITLE
Added support for node affinity labels

### DIFF
--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -107,6 +107,7 @@ type FlatConfig struct {
 	OmitExternalIP               *bool                      `mapstructure:"omit_external_ip" required:"false" cty:"omit_external_ip" hcl:"omit_external_ip"`
 	OnHostMaintenance            *string                    `mapstructure:"on_host_maintenance" required:"false" cty:"on_host_maintenance" hcl:"on_host_maintenance"`
 	Preemptible                  *bool                      `mapstructure:"preemptible" required:"false" cty:"preemptible" hcl:"preemptible"`
+	NodeAffinities               []FlatNodeAffinity         `mapstructure:"node_affinity" required:"false" cty:"node_affinity" hcl:"node_affinity"`
 	StateTimeout                 *string                    `mapstructure:"state_timeout" required:"false" cty:"state_timeout" hcl:"state_timeout"`
 	Region                       *string                    `mapstructure:"region" required:"false" cty:"region" hcl:"region"`
 	Scopes                       []string                   `mapstructure:"scopes" required:"false" cty:"scopes" hcl:"scopes"`
@@ -235,6 +236,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"omit_external_ip":                &hcldec.AttrSpec{Name: "omit_external_ip", Type: cty.Bool, Required: false},
 		"on_host_maintenance":             &hcldec.AttrSpec{Name: "on_host_maintenance", Type: cty.String, Required: false},
 		"preemptible":                     &hcldec.AttrSpec{Name: "preemptible", Type: cty.Bool, Required: false},
+		"node_affinity":                   &hcldec.BlockListSpec{TypeName: "node_affinity", Nested: hcldec.ObjectSpec((*FlatNodeAffinity)(nil).HCL2Spec())},
 		"state_timeout":                   &hcldec.AttrSpec{Name: "state_timeout", Type: cty.String, Required: false},
 		"region":                          &hcldec.AttrSpec{Name: "region", Type: cty.String, Required: false},
 		"scopes":                          &hcldec.AttrSpec{Name: "scopes", Type: cty.List(cty.String), Required: false},
@@ -277,6 +279,33 @@ func (*FlatCustomerEncryptionKey) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"kmsKeyName": &hcldec.AttrSpec{Name: "kmsKeyName", Type: cty.String, Required: false},
 		"rawKey":     &hcldec.AttrSpec{Name: "rawKey", Type: cty.String, Required: false},
+	}
+	return s
+}
+
+// FlatNodeAffinity is an auto-generated flat version of NodeAffinity.
+// Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
+type FlatNodeAffinity struct {
+	Key      *string  `mapstructure:"key" json:"key" cty:"key" hcl:"key"`
+	Operator *string  `mapstructure:"operator" json:"operator" cty:"operator" hcl:"operator"`
+	Values   []string `mapstructure:"values" json:"values" cty:"values" hcl:"values"`
+}
+
+// FlatMapstructure returns a new FlatNodeAffinity.
+// FlatNodeAffinity is an auto-generated flat version of NodeAffinity.
+// Where the contents a fields with a `mapstructure:,squash` tag are bubbled up.
+func (*NodeAffinity) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.Spec } {
+	return new(FlatNodeAffinity)
+}
+
+// HCL2Spec returns the hcl spec of a NodeAffinity.
+// This spec is used by HCL to read the fields of NodeAffinity.
+// The decoded values from this spec will then be applied to a FlatNodeAffinity.
+func (*FlatNodeAffinity) HCL2Spec() map[string]hcldec.Spec {
+	s := map[string]hcldec.Spec{
+		"key":      &hcldec.AttrSpec{Name: "key", Type: cty.String, Required: false},
+		"operator": &hcldec.AttrSpec{Name: "operator", Type: cty.String, Required: false},
+		"values":   &hcldec.AttrSpec{Name: "values", Type: cty.List(cty.String), Required: false},
 	}
 	return s
 }

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -151,6 +151,16 @@ func TestConfigPrepare(t *testing.T) {
 			true,
 		},
 		{
+			"node_affinity",
+			nil,
+			false,
+		},
+		{
+			"node_affinity",
+			map[string]interface{}{"key": "workload", "operator": "IN", "values": []string{"packer"}},
+			false,
+		},
+		{
 			"image_family",
 			nil,
 			false,

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -98,6 +98,7 @@ type InstanceConfig struct {
 	OmitExternalIP               bool
 	OnHostMaintenance            string
 	Preemptible                  bool
+	NodeAffinities               []NodeAffinity
 	Region                       string
 	ServiceAccountEmail          string
 	Scopes                       []string

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -196,6 +196,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		OmitExternalIP:               c.OmitExternalIP,
 		OnHostMaintenance:            c.OnHostMaintenance,
 		Preemptible:                  c.Preemptible,
+		NodeAffinities:               c.NodeAffinities,
 		Region:                       c.Region,
 		ServiceAccountEmail:          c.ServiceAccountEmail,
 		Scopes:                       c.Scopes,

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -165,6 +165,17 @@
 
 - `preemptible` (bool) - If true, launch a preemptible instance.
 
+- `node_affinity` ([]NodeAffinity) - Sets a node affinity label for the launched instance (eg. for sole tenancy).
+  Please see [Provisioning VMs on
+  sole-tenant nodes](https://cloud.google.com/compute/docs/nodes/provisioning-sole-tenant-vms)
+  for more information.
+  
+  ```hcl
+    key = "workload"
+    operator = "IN"
+    values = ["packer"]
+  ```
+
 - `state_timeout` (duration string | ex: "1h5m2s") - The time to wait for instance state changes. Defaults to "5m".
 
 - `region` (string) - The region in which to launch the instance. Defaults to the region

--- a/docs-partials/builder/googlecompute/NodeAffinity-not-required.mdx
+++ b/docs-partials/builder/googlecompute/NodeAffinity-not-required.mdx
@@ -1,0 +1,10 @@
+<!-- Code generated from the comments of the NodeAffinity struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
+
+- `key` (string) - Key: Corresponds to the label key of Node resource.
+
+- `operator` (string) - Operator: Defines the operation of node selection. Valid operators are IN for affinity and
+  NOT_IN for anti-affinity.
+
+- `values` ([]string) - Values: Corresponds to the label values of Node resource.
+
+<!-- End of code generated from the comments of the NodeAffinity struct in builder/googlecompute/config.go; -->

--- a/docs-partials/builder/googlecompute/NodeAffinity.mdx
+++ b/docs-partials/builder/googlecompute/NodeAffinity.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the NodeAffinity struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
+
+Node affinity label configuration
+
+<!-- End of code generated from the comments of the NodeAffinity struct in builder/googlecompute/config.go; -->

--- a/docs-partials/builder/googlecompute/NodeAffinityConfig-not-required.mdx
+++ b/docs-partials/builder/googlecompute/NodeAffinityConfig-not-required.mdx
@@ -1,0 +1,10 @@
+<!-- Code generated from the comments of the NodeAffinityConfig struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
+
+- `key` (string) - Key: Corresponds to the label key of Node resource.
+
+- `operator` (string) - Operator: Defines the operation of node selection. Valid operators are IN for affinity and
+  NOT_IN for anti-affinity.
+
+- `values` ([]string) - Values: Corresponds to the label values of Node resource.
+
+<!-- End of code generated from the comments of the NodeAffinityConfig struct in builder/googlecompute/config.go; -->

--- a/docs-partials/builder/googlecompute/NodeAffinityConfig.mdx
+++ b/docs-partials/builder/googlecompute/NodeAffinityConfig.mdx
@@ -1,0 +1,5 @@
+<!-- Code generated from the comments of the NodeAffinityConfig struct in builder/googlecompute/config.go; DO NOT EDIT MANUALLY -->
+
+Node affinity label configuration
+
+<!-- End of code generated from the comments of the NodeAffinityConfig struct in builder/googlecompute/config.go; -->


### PR DESCRIPTION
Adds support for `node_affinity` field in googlecompute source. Example:

```hcl
  node_affinity { 
    key = "workload"
    operator = "IN"
    values = ["packer"]
  }
  node_affinity { 
    key = "workload"
    operator = "NOT_IN"
    values = ["notpacker"]
  }
```

I put WIP in the title because the test are giving me a panic which seems to be unrelated to my changes. However, I tested  building images with and without `node_affinity` configs. Also I'm not sure what parts get autogenerated and I shouldn't be including in my PR.

The PR also touches the `waitForState` mechanism, because if a sole-tenant node is not available the operation state becomes `DONE` but there is a precondition failed error emitted, which is flagged as a retryable error and will keep the function spinning until timeout. I'm also fine with taking that out, in case you think it's too much.

Closes #93

