### PR TITLE
Remove unneeded Sprintf

### DIFF
--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -2,7 +2,6 @@ package googlecompute
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"runtime"

--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -75,7 +75,7 @@ set "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE=/path/to/account_file.json"
 call gcloud compute start-iap-tunnel fakeinstance-12345 1234 --local-host-port=localhost:8774 --zone us-central-b --project fake-project-123
 `
 	}
-	if fmt.Sprintf("%s", f) != expected {
+	if string(f) != expected {
 		t.Fatalf("script didn't match expected:\n\n expected: \n%s\n; recieved: \n%s\n", expected, f)
 	}
 }


### PR DESCRIPTION
```
jasonhatton@localhost:~/code/packer-plugin-googlecompute$ golangci-lint run
builder/googlecompute/step_start_tunnel_test.go:78:5: S1025: the argument's underlying type is a slice of bytes, should use a simple conversion instead of fmt.Sprintf (gosimple)
        if fmt.Sprintf("%s", f) != expected {
```
This PR fixes this lint.
