### PR TITLE
Add ml-images project to list of supported images

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -294,6 +294,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"google-containers",
 		"opensuse-cloud",
 		"ubuntu-os-pro-cloud",
+		"ml-images",
 	}
 	return d.GetImageFromProjects(projects, name, fromFamily)
 }


### PR DESCRIPTION
Hi! I noticed that the `ml-images` project is missing from the search path of `*driverGCE.GetImageFromProjects`. Just added it.

You can verify the existence of the `ml-images` project by using the command:
```sh
▶ gcloud compute images describe-from-family common-dl-gpu-debian-10 --project=ml-images
archiveSizeBytes: '31754872320'
creationTimestamp: '2022-07-01T16:00:12.498-07:00'
description: Google, Debian 10 based Deep Learning VM with CUDA 11.3, M94, Base CUDA
  11.3, Deep Learning VM Image with CUDA 11.3 preinstalled.
diskSizeGb: '50'
family: common-dl-gpu-debian-10
guestOsFeatures:
- type: VIRTIO_SCSI_MULTIQUEUE
- type: UEFI_COMPATIBLE
- type: GVNIC
id: '6830904170410853011'
kind: compute#image
labelFingerprint: 42WmSpB8rSM=
licenseCodes:
- '5638175847114525401'
- '1045467480970708420'
- '820365891328006231'
- '1814223386218908828'
- '2037264782083279710'
- '5592494605997326117'
licenses:
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-tensorflow
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-dl-platform-gvnic
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-dl-platform-gpu-common-cu110
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-dl-platform-debian-10
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-dl-platform-ml-images
- https://www.googleapis.com/compute/v1/projects/click-to-deploy-images/global/licenses/c2d-dl-platform-dlvm
name: c0-deeplearning-common-cu113-v20220701-debian-10
rawDisk:
  containerType: TAR
  source: ''
selfLink: https://www.googleapis.com/compute/v1/projects/ml-images/global/images/c0-deeplearning-common-cu113-v20220701-debian-10
sourceType: RAW
status: READY
storageLocations:
- us
- asia
- eu
```
