### PR TITLE
Add support for AlamaLinux, FreeBSD, and HPC cloud images 

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -275,11 +275,14 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		d.projectId,
 		// Public projects, drawn from
 		// https://cloud.google.com/compute/docs/images
+		"almalinux-cloud",
 		"centos-cloud",
+		"cloud-hpc-image-public",
 		"cos-cloud",
 		"coreos-cloud",
 		"debian-cloud",
 		"fedora-cloud",
+		"freebsd-org-cloud-dev",
 		"rhel-cloud",
 		"rhel-sap-cloud",
 		"rocky-linux-cloud",


### PR DESCRIPTION
The newer community project images such as alma-linux listed on the https://cloud.google.com/compute/docs/images
page are not yet available on the plugin.

Updating the driver project ID list to include these newly available images

Closes #119 


