### PR TITLE
Add alamalinux-cloud as supported community project

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -294,6 +294,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"google-containers",
 		"opensuse-cloud",
 		"ubuntu-os-pro-cloud",
+		"almalinux-cloud",
 	}
 	return d.GetImageFromProjects(projects, name, fromFamily)
 }


### PR DESCRIPTION
Closes #119

```
~>  packer build /tmp/source.pkr.hcl
googlecompute.alma: output will be in this color.

==> googlecompute.alma: Checking image does not exist...
==> googlecompute.alma: Creating temporary RSA SSH key for instance...
==> googlecompute.alma: Using image: almalinux-9-v20220920
==> googlecompute.alma: Creating instance...
    googlecompute.alma: Loading zone: us-west1-a
    googlecompute.alma: Loading machine type: n1-standard-1
    googlecompute.alma: Requesting instance creation...
    googlecompute.alma: Waiting for creation operation to complete...
    googlecompute.alma: Instance has been created!
==> googlecompute.alma: Waiting for the instance to become running...
[...]

Build 'googlecompute.alma' finished after 1 minute 51 seconds.
==> Builds finished. The artifacts of successful builds are:
--> googlecompute.alma: A disk image was created: myalma
```
