### PR TITLE
We should suggest users to use above v1.0.0

### DIFF
--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -32,7 +32,7 @@ this code into your Packer configuration to do so. Then, run `packer init`.
 packer {
   required_plugins {
     googlecompute = {
-      version = ">= 0.0.1"
+      version = ">= 1.0.0"
       source = "github.com/hashicorp/googlecompute"
     }
   }


### PR DESCRIPTION
In this PR, we are going to update our official document to suggest users to use above v1.0.0, currently we left v0.0.1 that is outdated.
https://developer.hashicorp.com/packer/plugins/builders/googlecompute

v0.0.1 has a fundamental problem, this update could avoid these reports in the future.
https://github.com/hashicorp/packer-plugin-googlecompute/issues/24

The repository's README.md already recommends users to use v1.0.0, public document should be aligned with it.
https://github.com/officer/packer-plugin-googlecompute/blob/fix-document/README.md#installation