### PR TITLE
docs/builder: Fix reference to SSH partial

### DIFF
--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -462,7 +462,7 @@ builder.
 
 @include 'packer-plugin-sdk/communicator/SSH-not-required.mdx'
 
-&include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
+@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
 
 ### Required:
 


### PR DESCRIPTION
Documentation is broken
![image](https://user-images.githubusercontent.com/1749304/231882334-a26a4275-9151-40df-9872-9f231038891d.png)

Closes #134 