### PR TITLE
builder: add log for ssh_username with oslogin

### DIFF
--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -120,9 +120,7 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 		}
 	}
 
-	if s.Debug {
-		ui.Message(fmt.Sprintf("ssh_username: %s", username))
-	}
+	log.Printf("[DEBUG] OSLogin step, setting ssh_username: %s", username)
 	config.Comm.SSHUsername = username
 
 	return multistep.ActionContinue


### PR DESCRIPTION
The ssh username picked from the account credentials was only printed out as a message when running Packer with the `--debug' flag, making it impossible to see when running unattended builds, like in tests for example.

To remedy this issue, and see the actual username derived from the credentials, we make this message a debug log so it's always visible when running Packer with `PACKER_LOG' set.