### PR TITLE
builder: leverage AutoDelete for persistent disks

### DIFF
--- a/builder/googlecompute/block_device.go
+++ b/builder/googlecompute/block_device.go
@@ -281,6 +281,19 @@ func (bd BlockDevice) generateComputeDiskPayload() (*compute.Disk, error) {
 	return payload, nil
 }
 
+// shouldAutoDelete returns whether the disk should be automatically deleted after build is done.
+func (bd BlockDevice) shouldAutoDelete() bool {
+	if bd.VolumeType == LocalScratch {
+		return true
+	}
+
+	if bd.KeepDevice {
+		return false
+	}
+
+	return true
+}
+
 func (bd BlockDevice) generateDiskAttachment() *compute.AttachedDisk {
 	if bd.VolumeType == LocalScratch {
 		return &compute.AttachedDisk{
@@ -298,6 +311,7 @@ func (bd BlockDevice) generateDiskAttachment() *compute.AttachedDisk {
 	}
 
 	return &compute.AttachedDisk{
+		AutoDelete:        bd.shouldAutoDelete(),
 		Boot:              false,
 		DeviceName:        bd.DeviceName,
 		Interface:         bd.InterfaceType,

--- a/builder/googlecompute/block_device_test.go
+++ b/builder/googlecompute/block_device_test.go
@@ -339,7 +339,7 @@ func TestGenerateDiskAttachment(t *testing.T) {
 				zone:           "us-central1-a",
 			},
 			expectval: &compute.AttachedDisk{
-				AutoDelete:        false,
+				AutoDelete:        true,
 				Boot:              false,
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{},
 				Interface:         "NVME",
@@ -358,6 +358,45 @@ func TestGenerateDiskAttachment(t *testing.T) {
 				zone:           "us-central1-a",
 			},
 			expectval: &compute.AttachedDisk{
+				AutoDelete:        true,
+				Boot:              false,
+				DiskEncryptionKey: &compute.CustomerEncryptionKey{},
+				Interface:         "NVME",
+				Mode:              "READ_ONLY",
+				Type:              "PERSISTENT",
+				DeviceName:        "packer-test",
+			},
+		},
+		{
+			name: "basic persistent disk from source",
+			config: BlockDevice{
+				AttachmentMode: "READ_ONLY",
+				InterfaceType:  "NVME",
+				zone:           "us-central1-a",
+				SourceVolume:   "dummy_source",
+			},
+			expectval: &compute.AttachedDisk{
+				AutoDelete:        false,
+				Boot:              false,
+				DiskEncryptionKey: &compute.CustomerEncryptionKey{},
+				Interface:         "NVME",
+				Mode:              "READ_ONLY",
+				Type:              "PERSISTENT",
+				Source:            "dummy_source",
+			},
+		},
+		{
+			name: "basic persistent disk with keep device",
+			config: BlockDevice{
+				VolumeSize:     25,
+				VolumeType:     "pd-standard",
+				AttachmentMode: "READ_ONLY",
+				InterfaceType:  "NVME",
+				DeviceName:     "packer-test",
+				zone:           "us-central1-a",
+				KeepDevice:     true,
+			},
+			expectval: &compute.AttachedDisk{
 				AutoDelete:        false,
 				Boot:              false,
 				DiskEncryptionKey: &compute.CustomerEncryptionKey{},
@@ -373,7 +412,7 @@ func TestGenerateDiskAttachment(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			err := tt.config.Prepare()
 			if err != nil {
-				t.Fatalf("failed to prepare config: %#v", err)
+				t.Fatalf("failed to prepare config: %s", err)
 			}
 
 			att := tt.config.generateDiskAttachment()

--- a/builder/googlecompute/builder_acc_test.go
+++ b/builder/googlecompute/builder_acc_test.go
@@ -207,6 +207,16 @@ func TestAccBuilder_WithExtraPersistentDisk(t *testing.T) {
 					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 				}
 			}
+
+			logs, err := os.ReadFile(logfile)
+			if err != nil {
+				t.Fatalf("failed to open logfile %q: %s", logfile, err)
+			}
+
+			if strings.Contains(string(logs), "Deleting persistent disk") {
+				t.Errorf("extra persistent disk should be automatically deleted on instance tear-down, but was deleted during the cleanup for the step_extra_disks")
+			}
+
 			return nil
 		},
 	}
@@ -228,6 +238,16 @@ func TestAccBuilder_WithExtraPersistentDiskAndRegions(t *testing.T) {
 					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 				}
 			}
+
+			logs, err := os.ReadFile(logfile)
+			if err != nil {
+				t.Fatalf("failed to open logfile %q: %s", logfile, err)
+			}
+
+			if strings.Contains(string(logs), "Deleting persistent disk") {
+				t.Errorf("extra persistent disk should be automatically deleted on instance tear-down, but was deleted during the cleanup for the step_extra_disks")
+			}
+
 			return nil
 		},
 	}
@@ -249,6 +269,16 @@ func TestAccBuilder_WithMultipleDisks(t *testing.T) {
 					return fmt.Errorf("Bad exit code. Logfile: %s", logfile)
 				}
 			}
+
+			logs, err := os.ReadFile(logfile)
+			if err != nil {
+				t.Fatalf("failed to open logfile %q: %s", logfile, err)
+			}
+
+			if strings.Contains(string(logs), "Deleting persistent disk") {
+				t.Errorf("extra persistent disk should be automatically deleted on instance tear-down, but was deleted during the cleanup for the step_extra_disks")
+			}
+
 			return nil
 		},
 	}

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -31,6 +31,9 @@ type Driver interface {
 	// DeleteDisk deletes the disk with the given name.
 	DeleteDisk(zone, name string) <-chan error
 
+	// GetDisk gets the disk with the given name in a zone/region.
+	GetDisk(zone, name string) (*compute.Disk, error)
+
 	// GetImage gets an image; tries the default and public projects. If
 	// fromFamily is true, name designates an image family instead of a
 	// particular image.

--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -400,6 +400,14 @@ func (d *driverGCE) deleteRegionalDisk(region, name string) <-chan error {
 	return errCh
 }
 
+func (d *driverGCE) GetDisk(zoneOrRegion, name string) (*compute.Disk, error) {
+	if isZoneARegion(zoneOrRegion) {
+		return d.service.RegionDisks.Get(d.projectId, zoneOrRegion, name).Do()
+	}
+
+	return d.service.Disks.Get(d.projectId, zoneOrRegion, name).Do()
+}
+
 func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 
 	projects := []string{

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -46,6 +46,11 @@ type DriverMock struct {
 	DeleteDiskErrCh chan error
 	DeleteDiskErr   error
 
+	GetDiskName   string
+	GetDiskZone   string
+	GetDiskResult *compute.Disk
+	GetDiskErr    error
+
 	GetImageName           string
 	GetImageSourceProjects []string
 	GetImageFromFamily     bool
@@ -222,6 +227,13 @@ func (d *DriverMock) DeleteDisk(zone, name string) <-chan error {
 	close(resultCh)
 
 	return resultCh
+}
+
+func (d *DriverMock) GetDisk(zoneOrRegion, name string) (*compute.Disk, error) {
+	d.GetDiskZone = zoneOrRegion
+	d.GetDiskName = name
+
+	return d.GetDiskResult, d.GetDiskErr
 }
 
 func (d *DriverMock) GetImage(name string, fromFamily bool) (*Image, error) {


### PR DESCRIPTION
In previous versions of the plugin, we'd remove disks manually, one by one, after the instance was torn-down.

However, there's an AutoDelete boolean that we can set for disks at instance creation time, which takes care of deleting those for us.

This commit sets this boolean to the appropriate value so they're automatically deleted, and we keep on checking/deleting manually some of those disks after that should one fail to be deleted during this step.

This should mitigate issues with the cleanup phase for this step, and ensure disks are indeed removed.

Closes #158 

