### PR TITLE
feat: adds image_project_id parameter for pushing images to a different GCP project

### DIFF
--- a/builder/googlecompute/artifact.go
+++ b/builder/googlecompute/artifact.go
@@ -30,7 +30,7 @@ func (*Artifact) BuilderId() string {
 // Destroy destroys the GCE image represented by the artifact.
 func (a *Artifact) Destroy() error {
 	log.Printf("Destroying image: %s", a.image.Name)
-	errCh := a.driver.DeleteImage(a.image.Name)
+	errCh := a.driver.DeleteImage(a.config.ImageProjectId, a.image.Name)
 	return <-errCh
 }
 
@@ -46,7 +46,8 @@ func (a *Artifact) Id() string {
 
 // String returns the string representation of the artifact.
 func (a *Artifact) String() string {
-	return fmt.Sprintf("A disk image was created: %v", a.image.Name)
+	return fmt.Sprintf("A disk image was created in the '%v' project: %v",
+		a.config.ImageProjectId, a.image.Name)
 }
 
 func (a *Artifact) State(name string) interface{} {

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -157,6 +157,8 @@ type Config struct {
 	ImageLicenses []string `mapstructure:"image_licenses" required:"false"`
 	// Guest OS features to apply to the created image.
 	ImageGuestOsFeatures []string `mapstructure:"image_guest_os_features" required:"false"`
+	// The project ID to push the build image into. Defaults to project_id.
+	ImageProjectId string `mapstructure:"image_project_id" required:"false"`
 	// Storage location, either regional or multi-regional, where snapshot
 	// content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional
 	// location.
@@ -406,6 +408,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.DiskType == "" {
 		c.DiskType = "pd-standard"
+	}
+
+	if c.ImageProjectId == "" {
+		c.ImageProjectId = c.ProjectId
 	}
 
 	// Disabling the vTPM also disables integrity monitoring, because integrity

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -97,6 +97,7 @@ type FlatConfig struct {
 	ImageLabels                  map[string]string          `mapstructure:"image_labels" required:"false" cty:"image_labels" hcl:"image_labels"`
 	ImageLicenses                []string                   `mapstructure:"image_licenses" required:"false" cty:"image_licenses" hcl:"image_licenses"`
 	ImageGuestOsFeatures         []string                   `mapstructure:"image_guest_os_features" required:"false" cty:"image_guest_os_features" hcl:"image_guest_os_features"`
+	ImageProjectId               *string                    `mapstructure:"image_project_id" required:"false" cty:"image_project_id" hcl:"image_project_id"`
 	ImageStorageLocations        []string                   `mapstructure:"image_storage_locations" required:"false" cty:"image_storage_locations" hcl:"image_storage_locations"`
 	InstanceName                 *string                    `mapstructure:"instance_name" required:"false" cty:"instance_name" hcl:"instance_name"`
 	Labels                       map[string]string          `mapstructure:"labels" required:"false" cty:"labels" hcl:"labels"`
@@ -228,6 +229,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"image_labels":                    &hcldec.AttrSpec{Name: "image_labels", Type: cty.Map(cty.String), Required: false},
 		"image_licenses":                  &hcldec.AttrSpec{Name: "image_licenses", Type: cty.List(cty.String), Required: false},
 		"image_guest_os_features":         &hcldec.AttrSpec{Name: "image_guest_os_features", Type: cty.List(cty.String), Required: false},
+		"image_project_id":                &hcldec.AttrSpec{Name: "image_project_id", Type: cty.String, Required: false},
 		"image_storage_locations":         &hcldec.AttrSpec{Name: "image_storage_locations", Type: cty.List(cty.String), Required: false},
 		"instance_name":                   &hcldec.AttrSpec{Name: "instance_name", Type: cty.String, Required: false},
 		"labels":                          &hcldec.AttrSpec{Name: "labels", Type: cty.Map(cty.String), Required: false},

--- a/builder/googlecompute/driver.go
+++ b/builder/googlecompute/driver.go
@@ -20,10 +20,10 @@ type Driver interface {
 
 	// CreateImage creates an image from the given disk in Google Compute
 	// Engine.
-	CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_guest_os_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
+	CreateImage(project, name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_guest_os_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocation []string) (<-chan *Image, <-chan error)
 
 	// DeleteImage deletes the image with the given name.
-	DeleteImage(name string) <-chan error
+	DeleteImage(project, name string) <-chan error
 
 	// DeleteInstance deletes the given instance, keeping the boot disk.
 	DeleteInstance(zone, name string) (<-chan error, error)
@@ -62,7 +62,7 @@ type Driver interface {
 
 	// ImageExists returns true if the specified image exists. If an error
 	// occurs calling the API, this method returns false.
-	ImageExists(name string) bool
+	ImageExists(project, name string) bool
 
 	// RunInstance takes the given config and launches an instance.
 	RunInstance(*InstanceConfig) (<-chan error, error)

--- a/builder/googlecompute/driver_mock.go
+++ b/builder/googlecompute/driver_mock.go
@@ -17,6 +17,7 @@ type DriverMock struct {
 	CreateDiskResultCh <-chan *compute.Disk
 	CreateDiskErrCh    <-chan error
 
+	CreateImageProjectId        string
 	CreateImageName             string
 	CreateImageDesc             string
 	CreateImageFamily           string
@@ -33,6 +34,7 @@ type DriverMock struct {
 	CreateImageErrCh            <-chan error
 	CreateImageResultCh         <-chan *Image
 
+	DeleteProjectId  string
 	DeleteImageName  string
 	DeleteImageErrCh <-chan error
 
@@ -84,8 +86,9 @@ type DriverMock struct {
 	GetSerialPortOutputResult string
 	GetSerialPortOutputErr    error
 
-	ImageExistsName   string
-	ImageExistsResult bool
+	ImageExistsProjectId string
+	ImageExistsName      string
+	ImageExistsResult    bool
 
 	RunInstanceConfig *InstanceConfig
 	RunInstanceErrCh  <-chan error
@@ -109,7 +112,8 @@ type DriverMock struct {
 	AddToInstanceMetadataErr     error
 }
 
-func (d *DriverMock) CreateImage(name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
+func (d *DriverMock) CreateImage(project, name, description, family, zone, disk string, image_labels map[string]string, image_licenses []string, image_features []string, image_encryption_key *compute.CustomerEncryptionKey, imageStorageLocations []string) (<-chan *Image, <-chan error) {
+	d.CreateImageProjectId = project
 	d.CreateImageName = name
 	d.CreateImageDesc = description
 	d.CreateImageFamily = family
@@ -163,7 +167,8 @@ func (d *DriverMock) CreateImage(name, description, family, zone, disk string, i
 	return resultCh, errCh
 }
 
-func (d *DriverMock) DeleteImage(name string) <-chan error {
+func (d *DriverMock) DeleteImage(project, name string) <-chan error {
+	d.DeleteProjectId = project
 	d.DeleteImageName = name
 
 	resultCh := d.DeleteImageErrCh
@@ -280,7 +285,8 @@ func (d *DriverMock) GetSerialPortOutput(zone, name string) (string, error) {
 	return d.GetSerialPortOutputResult, d.GetSerialPortOutputErr
 }
 
-func (d *DriverMock) ImageExists(name string) bool {
+func (d *DriverMock) ImageExists(project, name string) bool {
+	d.ImageExistsProjectId = project
 	d.ImageExistsName = name
 	return d.ImageExistsResult
 }

--- a/builder/googlecompute/step_check_existing_image.go
+++ b/builder/googlecompute/step_check_existing_image.go
@@ -22,10 +22,10 @@ func (s *StepCheckExistingImage) Run(ctx context.Context, state multistep.StateB
 	ui := state.Get("ui").(packersdk.Ui)
 
 	ui.Say("Checking image does not exist...")
-	c.imageAlreadyExists = d.ImageExists(c.ImageName)
+	c.imageAlreadyExists = d.ImageExists(c.ImageProjectId, c.ImageName)
 	if !c.PackerForce && c.imageAlreadyExists {
-		err := fmt.Errorf("Image %s already exists.\n"+
-			"Use the force flag to delete it prior to building.", c.ImageName)
+		err := fmt.Errorf("Image %s already exists in project %s.\n"+
+			"Use the force flag to delete it prior to building.", c.ImageName, c.ImageProjectId)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -34,7 +34,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	if config.PackerForce && config.imageAlreadyExists {
 		ui.Say("Deleting previous image...")
 
-		errCh := driver.DeleteImage(config.ImageName)
+		errCh := driver.DeleteImage(config.ImageProjectId, config.ImageName)
 		err := <-errCh
 		if err != nil {
 			err := fmt.Errorf("Error deleting image: %s", err)
@@ -47,7 +47,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	ui.Say("Creating image...")
 
 	imageCh, errCh := driver.CreateImage(
-		config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
+		config.ImageProjectId, config.ImageName, config.ImageDescription, config.ImageFamily, config.Zone,
 		config.DiskName, config.ImageLabels, config.ImageLicenses, config.ImageGuestOsFeatures,
 		config.ImageEncryptionKey.ComputeType(), config.ImageStorageLocations)
 	var err error
@@ -58,7 +58,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	if err != nil {
-		err := fmt.Errorf("Error waiting for image: %s", err)
+		err := fmt.Errorf("Error waiting for image: %s in", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -58,7 +58,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 	}
 
 	if err != nil {
-		err := fmt.Errorf("Error waiting for image: %s in", err)
+		err := fmt.Errorf("Error waiting for image: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
 		return multistep.ActionHalt

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -119,6 +119,7 @@
 - `image_licenses` ([]string) - Licenses to apply to the created image.
 
 - `image_guest_os_features` ([]string) - Guest OS features to apply to the created image.
+
 - `image_project_id` (string) - The project ID to push the build image into. Defaults to project_id.
 
 - `image_storage_locations` ([]string) - Storage location, either regional or multi-regional, where snapshot

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -119,6 +119,7 @@
 - `image_licenses` ([]string) - Licenses to apply to the created image.
 
 - `image_guest_os_features` ([]string) - Guest OS features to apply to the created image.
+- `image_project_id` (string) - The project ID to push the build image into. Defaults to project_id.
 
 - `image_storage_locations` ([]string) - Storage location, either regional or multi-regional, where snapshot
   content is to be stored and only accepts 1 value. Always defaults to a nearby regional or multi-regional

--- a/docs/builders/googlecompute.mdx
+++ b/docs/builders/googlecompute.mdx
@@ -444,6 +444,49 @@ build {
 </Tab>
 </Tabs>
 
+### Separate Image Project Example
+
+This is an example of using the `image_project_id` configuration option to create
+the generated image in a different GCP project than the one used to create the virtual machine. Make sure that Packer has permission in the target project to manage images, the `Compute Storage Admin` role will grant the desired permissions.
+
+<Tabs>
+<Tab heading="JSON">
+
+```json
+{
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "my project",
+      "image_project_id": "my image target project",
+      "source_image": "debian-9-stretch-v20200805",
+      "ssh_username": "packer",
+      "zone": "us-central1-a"
+    }
+  ]
+}
+```
+
+</Tab>
+<Tab heading="HCL2">
+
+```hcl
+source "googlecompute" "basic-example" {
+  project_id = "my project"
+  image_project_id = "my image target project"
+  source_image = "debian-9-stretch-v20200805"
+  ssh_username = "packer"
+  zone = "us-central1-a"
+}
+
+build {
+  sources = ["sources.googlecompute.basic-example"]
+}
+```
+
+</Tab>
+</Tabs>
+
 ## Configuration Reference
 
 Configuration options are organized below into two categories: required and


### PR DESCRIPTION
This PR resurrects and rebases [this](https://github.com/hashicorp/packer-plugin-googlecompute/pull/31) PR which creates an image_project_id configuration option (which defaults to project_id) and allows defining a different project that an image should be created in.

Closes https://github.com/hashicorp/packer-plugin-googlecompute/issues/30
