### PR TITLE
change default machine type to e2-standard-2

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -181,7 +181,7 @@ type Config struct {
 	InstanceName string `mapstructure:"instance_name" required:"false"`
 	// Key/value pair labels to apply to the launched instance.
 	Labels map[string]string `mapstructure:"labels" required:"false"`
-	// The machine type. Defaults to "n1-standard-1".
+	// The machine type. Defaults to "e2-standard-2".
 	MachineType string `mapstructure:"machine_type" required:"false"`
 	// Metadata applied to the launched instance.
 	// All metadata configuration values are expected to be of type string.
@@ -489,7 +489,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	}
 
 	if c.MachineType == "" {
-		c.MachineType = "n1-standard-1"
+		c.MachineType = "e2-standard-2"
 	}
 
 	if c.StateTimeout == 0 {

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -144,7 +144,7 @@
 
 - `labels` (map[string]string) - Key/value pair labels to apply to the launched instance.
 
-- `machine_type` (string) - The machine type. Defaults to "n1-standard-1".
+- `machine_type` (string) - The machine type. Defaults to "e2-standard-2".
 
 - `metadata` (map[string]string) - Metadata applied to the launched instance.
   All metadata configuration values are expected to be of type string.


### PR DESCRIPTION
### What
This PR will change default machine_type from `n1-standard-1` to `e2-standard-2`.

### Why

`n1-standard-1` is an old machine type and it's often not available. I confirmed with asia-northeast1-a, b, c zones.