### PR TITLE
feat: add `image_source_disk` configuration setting

### DIFF
--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -633,6 +633,58 @@ func TestConfigExtraBlockDevice_zone_forwarded(t *testing.T) {
 	}
 }
 
+func TestConfigExtraBlockDevice_create_image(t *testing.T) {
+	var config Config
+
+	c, _ := testConfig(t)
+
+	c["disk_attachment"] = []map[string]interface{}{
+		{
+			"volume_type":  "pd-standard",
+			"volume_size":  20,
+			"disk_name":    "second-disk",
+			"create_image": true,
+		},
+	}
+
+	_, err := config.Prepare(c)
+
+	if err != nil {
+		t.Fatalf("failed to prepare config: %#s", err)
+	}
+
+	if config.imageSourceDisk != "second-disk" {
+		t.Errorf("Expected imageSourceDisk (%q) to match second disk's disk_name (%q)", config.imageSourceDisk, "second-disk")
+	}
+}
+
+func TestConfigExtraBlockDevice_create_image_multiple(t *testing.T) {
+	var config Config
+
+	c, _ := testConfig(t)
+
+	c["disk_attachment"] = []map[string]interface{}{
+		{
+			"volume_type":  "pd-standard",
+			"volume_size":  20,
+			"disk_name":    "second-disk",
+			"create_image": true,
+		},
+		{
+			"volume_type":  "pd-standard",
+			"volume_size":  20,
+			"disk_name":    "third-disk",
+			"create_image": true,
+		},
+	}
+
+	_, err := config.Prepare(c)
+
+	if err == nil {
+		t.Fatalf("expected an error due to having multiple disks with create_image enabled, got nil")
+	}
+}
+
 // Helper stuff below
 
 func testConfig(t *testing.T) (config map[string]interface{}, tempAccountFile string) {

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -48,7 +48,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 	ui.Say("Creating image...")
 
-	sourceDiskURI := fmt.Sprintf("/compute/v1/projects/%s/zones/%s/disks/%s", config.ProjectId, config.Zone, config.DiskName)
+	sourceDiskURI := fmt.Sprintf("/compute/v1/projects/%s/zones/%s/disks/%s", config.ProjectId, config.Zone, config.imageSourceDisk)
 
 	imageFeatures := make([]*compute.GuestOsFeature, 0, len(config.ImageGuestOsFeatures))
 	for _, v := range config.ImageGuestOsFeatures {

--- a/docs-partials/lib/common/BlockDevice-not-required.mdx
+++ b/docs-partials/lib/common/BlockDevice-not-required.mdx
@@ -4,6 +4,11 @@
   
   Can be either READ_ONLY or READ_WRITE (default).
 
+- `create_image` (bool) - If true, an image will be created for this disk, instead of the boot disk.
+  
+  This only applies to non-scratch disks, and can only be specified on one disk at a
+  time.
+
 - `device_name` (string) - The device name as exposed to the OS in the /dev/disk/by-id/google-* directory
   
   If unspecified, the disk will have a default name in the form

--- a/lib/common/block_device.hcl2spec.go
+++ b/lib/common/block_device.hcl2spec.go
@@ -11,6 +11,7 @@ import (
 // Where the contents of a field with a `mapstructure:,squash` tag are bubbled up.
 type FlatBlockDevice struct {
 	AttachmentMode    *string                    `mapstructure:"attachment_mode" cty:"attachment_mode" hcl:"attachment_mode"`
+	CreateImage       *bool                      `mapstructure:"create_image" cty:"create_image" hcl:"create_image"`
 	DeviceName        *string                    `mapstructure:"device_name" cty:"device_name" hcl:"device_name"`
 	DiskEncryptionKey *FlatCustomerEncryptionKey `mapstructure:"disk_encryption_key" cty:"disk_encryption_key" hcl:"disk_encryption_key"`
 	DiskName          *string                    `mapstructure:"disk_name" cty:"disk_name" hcl:"disk_name"`
@@ -37,6 +38,7 @@ func (*BlockDevice) FlatMapstructure() interface{ HCL2Spec() map[string]hcldec.S
 func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 	s := map[string]hcldec.Spec{
 		"attachment_mode":     &hcldec.AttrSpec{Name: "attachment_mode", Type: cty.String, Required: false},
+		"create_image":        &hcldec.AttrSpec{Name: "create_image", Type: cty.Bool, Required: false},
 		"device_name":         &hcldec.AttrSpec{Name: "device_name", Type: cty.String, Required: false},
 		"disk_encryption_key": &hcldec.BlockSpec{TypeName: "disk_encryption_key", Nested: hcldec.ObjectSpec((*FlatCustomerEncryptionKey)(nil).HCL2Spec())},
 		"disk_name":           &hcldec.AttrSpec{Name: "disk_name", Type: cty.String, Required: false},


### PR DESCRIPTION
Hello! This pull request aims to allow a user to configure which disk is used when creating the GCE image from the packer instance. I've defaulted to the `disk_name`, which makes this backwards-compatible, but with this change you could now specify a `disk_name` from one of the `disk_attachment` blocks (#153).

We believe this functionality would be useful for a simpler way of taking an image, _not booting from it_, and adding extra data to it before producing a second image.

I'm open to changing the name of the setting or any other changes you may suggest. Thanks!
