### PR TITLE
builder: add fedora-coreos-cloud project

### DIFF
--- a/builder/googlecompute/driver_gce.go
+++ b/builder/googlecompute/driver_gce.go
@@ -421,6 +421,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"coreos-cloud",
 		"debian-cloud",
 		"fedora-cloud",
+		"fedora-coreos-cloud",
 		"freebsd-org-cloud-dev",
 		"rhel-cloud",
 		"rhel-sap-cloud",


### PR DESCRIPTION
When a user specifies a `image_family_name` to get the latest version of an image to build their custom image upon, the plugin attempts to get the family specified from a static list of projects.

In this case, a user attempted to get the `fedora-coreos-stable' family, present in the `fedora-coreos-cloud` project, which was not in the default list of the GCE driver.

This commit changes this.

Closes: #191 