### PR TITLE
Add `source_image` to `disk_attachment`

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -723,6 +723,10 @@ source "googlecompute" "example" {
   
   If this is specified, it won't be deleted after the instance is shut-down.
 
+- `source_image` (string) - The URI of the image to load
+  
+  This cannot be used with SourceVolume.
+
 - `_` (string) - Zone is the zone in which to create the disk in.
   
   It is not exposed since the parent config already specifies it

--- a/docs-partials/lib/common/BlockDevice-not-required.mdx
+++ b/docs-partials/lib/common/BlockDevice-not-required.mdx
@@ -55,6 +55,10 @@
   
   If this is specified, it won't be deleted after the instance is shut-down.
 
+- `source_image` (string) - The URI of the image to load
+  
+  This cannot be used with SourceVolume.
+
 - `_` (string) - Zone is the zone in which to create the disk in.
   
   It is not exposed since the parent config already specifies it

--- a/lib/common/block_device.hcl2spec.go
+++ b/lib/common/block_device.hcl2spec.go
@@ -22,6 +22,7 @@ type FlatBlockDevice struct {
 	SourceVolume      *string                    `mapstructure:"source_volume" cty:"source_volume" hcl:"source_volume"`
 	VolumeSize        *int                       `mapstructure:"volume_size" required:"true" cty:"volume_size" hcl:"volume_size"`
 	VolumeType        *BlockDeviceType           `mapstructure:"volume_type" required:"true" cty:"volume_type" hcl:"volume_type"`
+	SourceImage       *string                    `mapstructure:"source_image" required:"false" cty:"source_image" hcl:"source_image"`
 	Zone              *string                    `mapstructure:"_" cty:"_" hcl:"_"`
 }
 
@@ -49,6 +50,7 @@ func (*FlatBlockDevice) HCL2Spec() map[string]hcldec.Spec {
 		"source_volume":       &hcldec.AttrSpec{Name: "source_volume", Type: cty.String, Required: false},
 		"volume_size":         &hcldec.AttrSpec{Name: "volume_size", Type: cty.Number, Required: false},
 		"volume_type":         &hcldec.AttrSpec{Name: "volume_type", Type: cty.String, Required: false},
+		"source_image":        &hcldec.AttrSpec{Name: "source_image", Type: cty.String, Required: false},
 		"_":                   &hcldec.AttrSpec{Name: "_", Type: cty.String, Required: false},
 	}
 	return s

--- a/lib/common/block_device_test.go
+++ b/lib/common/block_device_test.go
@@ -287,6 +287,15 @@ func TestBlockDevice_Prepare(t *testing.T) {
 			},
 			expectErr: true,
 		},
+		{
+			name: "fail - source volume set along with source image",
+			config: &BlockDevice{
+				SourceImage:  "projects/p/global/images/family/f",
+				SourceVolume: "zones/us-central1-a/disks/source-disk",
+				KeepDevice:   true,
+			},
+			expectErr: true,
+		},
 	}
 
 	for _, tt := range testcases {
@@ -404,6 +413,28 @@ func TestGenerateDiskAttachment(t *testing.T) {
 				Mode:              "READ_ONLY",
 				Type:              "PERSISTENT",
 				DeviceName:        "packer-test",
+			},
+		},
+		{
+			name: "basic persistent disk with source image",
+			config: BlockDevice{
+				SourceImage: "projects/p/global/images/family/f",
+				VolumeType:  "pd-standard",
+				DeviceName:  "packer-test",
+				DiskName:    "packer-test-disk",
+			},
+			expectval: &compute.AttachedDisk{
+				AutoDelete:        true,
+				Boot:              false,
+				DiskEncryptionKey: &compute.CustomerEncryptionKey{},
+				Interface:         "SCSI",
+				Mode:              "READ_WRITE",
+				Type:              "PERSISTENT",
+				DeviceName:        "packer-test",
+				InitializeParams: &compute.AttachedDiskInitializeParams{
+					DiskName:    "packer-test-disk",
+					SourceImage: "projects/p/global/images/family/f",
+				},
 			},
 		},
 	}


### PR DESCRIPTION
Add ability to specify a `source_image` in a `disk_attachment`.

Relevant excerpt from [GCP godocs](https://pkg.go.dev/google.golang.org/api/compute/v1#AttachedDiskInitializeParams):
```
	// SourceImage: The source image to create this disk. When creating a
	// new instance, one of initializeParams.sourceImage or
	// initializeParams.sourceSnapshot or disks.source is required except
	// for local SSD.
```

