### PR TITLE
Fix acceptance tests with local SSDs

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -129,6 +129,10 @@ builder.
   Scratch (ephemeral) SSDs are always created at launch, and deleted when the
   instance is torn-down.
   
+  Note: local SSDs are not supported on all machine types, refer to the
+  [docs](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds)
+  for more information on that.
+  
   Refer to the [Extra Disk Attachments](#extra-disk-attachments) section for
   more information on this configuration type.
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -116,6 +116,10 @@ type Config struct {
 	// Scratch (ephemeral) SSDs are always created at launch, and deleted when the
 	// instance is torn-down.
 	//
+	// Note: local SSDs are not supported on all machine types, refer to the
+	// [docs](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds)
+	// for more information on that.
+	//
 	// Refer to the [Extra Disk Attachments](#extra-disk-attachments) section for
 	// more information on this configuration type.
 	ExtraBlockDevices []BlockDevice `mapstructure:"disk_attachment" required:"false"`

--- a/builder/googlecompute/testdata/extra_scratch_disk.pkr.hcl
+++ b/builder/googlecompute/testdata/extra_scratch_disk.pkr.hcl
@@ -30,6 +30,7 @@ source "googlecompute" "test" {
   source_image_family = "centos-7"
   ssh_username        = var.ssh_username
   skip_create_image   = true
+  machine_type        = "n2-standard-2"
   zone                = var.zone
   disk_attachment {
     attachment_mode = "READ_WRITE"

--- a/builder/googlecompute/testdata/multiple_disks.pkr.hcl
+++ b/builder/googlecompute/testdata/multiple_disks.pkr.hcl
@@ -30,6 +30,7 @@ source "googlecompute" "test" {
   source_image_family = "centos-7"
   ssh_username        = var.ssh_username
   skip_create_image   = true
+  machine_type        = "n2-standard-2"
   zone                = var.zone
 
   disk_attachment {

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -81,6 +81,10 @@
   Scratch (ephemeral) SSDs are always created at launch, and deleted when the
   instance is torn-down.
   
+  Note: local SSDs are not supported on all machine types, refer to the
+  [docs](https://cloud.google.com/compute/docs/disks/local-ssd#choose_number_local_ssds)
+  for more information on that.
+  
   Refer to the [Extra Disk Attachments](#extra-disk-attachments) section for
   more information on this configuration type.
 


### PR DESCRIPTION
Some machine types don't support local SSDs as extra block devices, so we change our acceptance tests that contain those so they use n2-* machines instead of E2-*, which don't support those block device attachments.