### PR TITLE
post-processor: fix ignored error for artifact

### DIFF
--- a/post-processor/googlecompute-import/post-processor.go
+++ b/post-processor/googlecompute-import/post-processor.go
@@ -203,6 +203,9 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 	}
 
 	tarball, err := p.findTarballFromArtifact(artifact)
+	if err != nil {
+		return nil, false, false, err
+	}
 
 	rawImageGcsPath, err := driver.UploadToBucket(p.config.Bucket, p.config.GCSObjectName, tarball)
 	if err != nil {


### PR DESCRIPTION
The import post-processor attempts to find a tarball from the artifact's files in order to upload it to GCS.
The error returned by the code that attempts to get the tarball's path was ignored during the refactor, and the linter on GHA did not point to the error itself, leading me to believe this was a fluke due to the large diff.

This was not a fluke, and this is now fixed with this commit.