### PR TITLE
docs: mark plugin as hcp ready

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,6 +7,7 @@ integration {
   name = "Google Cloud Platform"
   description = "The googlecompute plugin can be used with HashiCorp Packer to create custom images on GCE."
   identifier = "packer/hashicorp/googlecompute"
+  flags = ["hcp-ready"]
   component {
     type = "builder"
     name = "Google Cloud Platform"


### PR DESCRIPTION
Since the plugin supports HCP Packer, we should tag it as such.