### PR TITLE
add omit_external_ip and use_internal_ip fields to export post-processor

### DIFF
--- a/.web-docs/components/post-processor/googlecompute-export/README.md
+++ b/.web-docs/components/post-processor/googlecompute-export/README.md
@@ -74,6 +74,12 @@ the [authentication](/packer/integrations/hashicorp/googlecompute#authentication
 
 - `service_account_email` (string) - Service Account Email
 
+- `omit_external_ip` (bool) - If true, the export instance will not have an external IP. use_internal_ip must
+  be true if this property is true.
+
+- `use_internal_ip` (bool) - If true, use the export instance's internal IP instead of its external IP
+  during exporting.
+
 <!-- End of code generated from the comments of the Config struct in post-processor/googlecompute-export/post-processor.go; -->
 
 

--- a/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
+++ b/docs-partials/post-processor/googlecompute-export/Config-not-required.mdx
@@ -35,4 +35,10 @@
 
 - `service_account_email` (string) - Service Account Email
 
+- `omit_external_ip` (bool) - If true, the export instance will not have an external IP. use_internal_ip must
+  be true if this property is true.
+
+- `use_internal_ip` (bool) - If true, use the export instance's internal IP instead of its external IP
+  during exporting.
+
 <!-- End of code generated from the comments of the Config struct in post-processor/googlecompute-export/post-processor.go; -->

--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -68,6 +68,12 @@ type Config struct {
 	Zone                string `mapstructure:"zone"`
 	IAP                 bool   `mapstructure-to-hcl2:",skip"`
 	ServiceAccountEmail string `mapstructure:"service_account_email"`
+	//If true, the export instance will not have an external IP. use_internal_ip must
+	//be true if this property is true.
+	OmitExternalIP bool `mapstructure:"omit_external_ip" required:"false"`
+	//If true, use the export instance's internal IP instead of its external IP
+	//during exporting.
+	UseInternalIP bool `mapstructure:"use_internal_ip" required:"false"`
 
 	ctx interpolate.Context
 }
@@ -183,6 +189,8 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		SourceImageProjectId: []string{"compute-image-tools"},
 		Subnetwork:           p.config.Subnetwork,
 		Zone:                 p.config.Zone,
+		OmitExternalIP:       p.config.OmitExternalIP,
+		UseInternalIP:        p.config.UseInternalIP,
 		Scopes: []string{
 			"https://www.googleapis.com/auth/compute",
 			"https://www.googleapis.com/auth/devstorage.full_control",

--- a/post-processor/googlecompute-export/post-processor.hcl2spec.go
+++ b/post-processor/googlecompute-export/post-processor.hcl2spec.go
@@ -33,6 +33,8 @@ type FlatConfig struct {
 	Subnetwork                *string           `mapstructure:"subnetwork" cty:"subnetwork" hcl:"subnetwork"`
 	Zone                      *string           `mapstructure:"zone" cty:"zone" hcl:"zone"`
 	ServiceAccountEmail       *string           `mapstructure:"service_account_email" cty:"service_account_email" hcl:"service_account_email"`
+	OmitExternalIP            *bool             `mapstructure:"omit_external_ip" required:"false" cty:"omit_external_ip" hcl:"omit_external_ip"`
+	UseInternalIP             *bool             `mapstructure:"use_internal_ip" required:"false" cty:"use_internal_ip" hcl:"use_internal_ip"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -70,6 +72,8 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"subnetwork":                  &hcldec.AttrSpec{Name: "subnetwork", Type: cty.String, Required: false},
 		"zone":                        &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
 		"service_account_email":       &hcldec.AttrSpec{Name: "service_account_email", Type: cty.String, Required: false},
+		"omit_external_ip":            &hcldec.AttrSpec{Name: "omit_external_ip", Type: cty.Bool, Required: false},
+		"use_internal_ip":             &hcldec.AttrSpec{Name: "use_internal_ip", Type: cty.Bool, Required: false},
 	}
 	return s
 }


### PR DESCRIPTION
After trying to use the `googlecompute-export` post-processor, it fails when provisioning the exporter instance because it violates the organization policy `constraints/compute.vmExternalIpAccess`.

This is the `packer` code used:

```hcl
source "googlecompute" "vm" {
  // ...
}

build {
  name = "main"
  sources = ["sources.googlecompute.vm"]
  // ...
  post-processor "googlecompute-export" {
    paths = [
      "gs://gs://$BUCKET_NAME/$IMAGE_NAME.tar.gz",
    ]
    keep_input_artifact = true
  }
}
```

and a fragment of the build logs:

```text
==> main.googlecompute.vm: Running post-processor: (type googlecompute-export)
==> main.googlecompute.vm (googlecompute-export): Exporting image $IMAGE_NAME to destination: [gs://$BUCKET_NAME/$IMAGE_NAME.tar.gz]
==> main.googlecompute.vm (googlecompute-export): Creating temporary RSA SSH key for instance...
==> main.googlecompute.vm (googlecompute-export): Using image: debian-9-worker-v20200616
==> main.googlecompute.vm (googlecompute-export): Creating instance...
    main.googlecompute.vm (googlecompute-export): Loading zone: $ZONE
    main.googlecompute.vm (googlecompute-export): Loading machine type: n1-highcpu-4
    main.googlecompute.vm (googlecompute-export): Requesting instance creation...
==> main.googlecompute.vm (googlecompute-export): Error creating instance: googleapi: Error 412: Constraint constraints/compute.vmExternalIpAccess violated for project $PROJECT_NUMBER. Add instance projects/$PROJECT_ID/zones/$ZONE/instances/$IMAGE_NAME-exporter to the constraint to use external IP with it., conditionNotMet
```

This happens because the provisioned export instance always has the fields `omit_external_ip` and `use_internal_ip` set to `false`, with no way to overwrite them.

This PR **attempts** to change that behavior, by exposing the aforementioned fields in the `googlecompute-export` post-processor config and then using them in the `googlecompute.Config` of the export instance.

Example:

```hcl
source "googlecompute" "vm" {
  // ...
}

build {
  name = "main"
  sources = ["sources.googlecompute.vm"]
  // ...
  post-processor "googlecompute-export" {
    paths = [
      "gs://gs://$BUCKET_NAME/$IMAGE_NAME.tar.gz",
    ]
    keep_input_artifact = true
    omit_external_ip    = true
    use_internal_ip     = true
  }
}
```

Please let me know if a way to circumvent this issue already exists. Any other feedback is welcome as well 🙂!