### PR TITLE
Image architecture config

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -130,6 +130,8 @@ builder.
 
 - `skip_create_image` (bool) - Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
+- `image_architecture` (string) - The architecture of the resulting image. Defaults to "x86_64".
+
 - `image_name` (string) - The unique name of the resulting image. Defaults to
   `packer-{{timestamp}}`.
 

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -94,6 +94,7 @@ type FlatConfig struct {
 	IAPExt                       *string                           `mapstructure:"iap_ext" required:"false" cty:"iap_ext" hcl:"iap_ext"`
 	IAPTunnelLaunchWait          *int                              `mapstructure:"iap_tunnel_launch_wait" required:"false" cty:"iap_tunnel_launch_wait" hcl:"iap_tunnel_launch_wait"`
 	SkipCreateImage              *bool                             `mapstructure:"skip_create_image" required:"false" cty:"skip_create_image" hcl:"skip_create_image"`
+	ImageArchitecture            *string                           `mapstructure:"image_architecture" required:"false" cty:"image_architecture" hcl:"image_architecture"`
 	ImageName                    *string                           `mapstructure:"image_name" required:"false" cty:"image_name" hcl:"image_name"`
 	ImageDescription             *string                           `mapstructure:"image_description" required:"false" cty:"image_description" hcl:"image_description"`
 	ImageEncryptionKey           *common.FlatCustomerEncryptionKey `mapstructure:"image_encryption_key" required:"false" cty:"image_encryption_key" hcl:"image_encryption_key"`
@@ -228,6 +229,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"iap_ext":                         &hcldec.AttrSpec{Name: "iap_ext", Type: cty.String, Required: false},
 		"iap_tunnel_launch_wait":          &hcldec.AttrSpec{Name: "iap_tunnel_launch_wait", Type: cty.Number, Required: false},
 		"skip_create_image":               &hcldec.AttrSpec{Name: "skip_create_image", Type: cty.Bool, Required: false},
+		"image_architecture":              &hcldec.AttrSpec{Name: "image_architecture", Type: cty.String, Required: false},
 		"image_name":                      &hcldec.AttrSpec{Name: "image_name", Type: cty.String, Required: false},
 		"image_description":               &hcldec.AttrSpec{Name: "image_description", Type: cty.String, Required: false},
 		"image_encryption_key":            &hcldec.BlockSpec{TypeName: "image_encryption_key", Nested: hcldec.ObjectSpec((*common.FlatCustomerEncryptionKey)(nil).HCL2Spec())},

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -64,7 +64,6 @@ func TestConfigPrepare(t *testing.T) {
 			"foo",
 			false,
 		},
-
 		{
 			"zone",
 			nil,
@@ -682,6 +681,35 @@ func TestConfigExtraBlockDevice_create_image_multiple(t *testing.T) {
 
 	if err == nil {
 		t.Fatalf("expected an error due to having multiple disks with create_image enabled, got nil")
+	}
+}
+
+func TestConfigPrepareImageArchitecture(t *testing.T) {
+	cases := []struct {
+		Architecture string
+		ExpectValid  bool
+	}{
+		{"X86_64", true},
+		{"ARM64", true},
+		{"arm64", true},
+		{"x86_64", true},
+		{"i386", false}, // Assuming 'i386' is not supported, adjust as needed
+	}
+
+	for _, tc := range cases {
+		raw, tempfile := testConfig(t)
+		defer os.Remove(tempfile)
+
+		raw["image_architecture"] = tc.Architecture
+
+		var c Config
+		_, errs := c.Prepare(raw)
+
+		if tc.ExpectValid && errs != nil {
+			t.Errorf("Expected architecture '%s' to be valid, but got error: %s", tc.Architecture, errs)
+		} else if !tc.ExpectValid && errs == nil {
+			t.Errorf("Expected architecture '%s' to be invalid, but got no error", tc.Architecture)
+		}
 	}
 }
 

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -57,6 +57,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 		})
 	}
 	imagePayload := &compute.Image{
+		Architecture:       config.ImageArchitecture,
 		Description:        config.ImageDescription,
 		Name:               config.ImageName,
 		Family:             config.ImageFamily,

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -76,6 +76,8 @@
 
 - `skip_create_image` (bool) - Skip creating the image. Useful for setting to `true` during a build test stage. Defaults to `false`.
 
+- `image_architecture` (string) - The architecture of the resulting image. Defaults to "x86_64".
+
 - `image_name` (string) - The unique name of the resulting image. Defaults to
   `packer-{{timestamp}}`.
 


### PR DESCRIPTION
This PR is to add image_architecture as a config for the packer plugin. Currently this plugin only supports provisioning Image Types of X86_64 in GCP disabling the ability to create ARM based images. 

image_architecture will allow consumers of this plugin to modify the disk type being provisioned by GCE to enable ARM based packer images in GCP. 

Test and validation are included with this PR to ensure that image_architecture is set to X86_64 or ARM64, by default it will select X86_64 as its the most common. This field is also optional so leaving it blank or an empty value will serve backwards compatibility for current configs. 