### PR TITLE
all: remove usage of ioutil

### DIFF
--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -5,7 +5,6 @@ package googlecompute
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"strings"
@@ -779,7 +778,7 @@ func testConfigOk(t *testing.T, warns []string, err error) {
 }
 
 func testAccountFile(t *testing.T) string {
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}
@@ -813,7 +812,7 @@ func testIAPScript(t *testing.T, c *Config) {
 const testMetadataFileContent = `testMetadata`
 
 func testMetadataFile(t *testing.T) string {
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -7,8 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"strings"
 	"time"
 
@@ -56,7 +56,7 @@ func (c *Config) createInstanceMetadata(sourceImage *common.Image, sshPublicKey 
 	startupScript := instanceMetadataNoSSHKeys[StartupScriptKey]
 	if c.StartupScriptFile != "" {
 		var content []byte
-		content, err = ioutil.ReadFile(c.StartupScriptFile)
+		content, err = os.ReadFile(c.StartupScriptFile)
 		if err != nil {
 			return nil, instanceMetadataNoSSHKeys, err
 		}
@@ -85,7 +85,7 @@ func (c *Config) createInstanceMetadata(sourceImage *common.Image, sshPublicKey 
 
 	for key, value := range c.MetadataFiles {
 		var content []byte
-		content, err = ioutil.ReadFile(value)
+		content, err = os.ReadFile(value)
 		if err != nil {
 			errs = packersdk.MultiErrorAppend(errs, err)
 		}

--- a/builder/googlecompute/step_create_windows_password_test.go
+++ b/builder/googlecompute/step_create_windows_password_test.go
@@ -6,7 +6,6 @@ package googlecompute
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 
 	"github.com/hashicorp/packer-plugin-googlecompute/lib/common"
@@ -75,7 +74,7 @@ func TestStepCreateOrResetWindowsPassword_dontNeedPassword(t *testing.T) {
 }
 
 func TestStepCreateOrResetWindowsPassword_debug(t *testing.T) {
-	tf, err := ioutil.TempFile("", "packer")
+	tf, err := os.CreateTemp("", "packer")
 	if err != nil {
 		t.Fatalf("err: %s", err)
 	}

--- a/builder/googlecompute/step_start_tunnel_test.go
+++ b/builder/googlecompute/step_start_tunnel_test.go
@@ -5,7 +5,6 @@ package googlecompute
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -60,7 +59,7 @@ func TestStepStartTunnel_CreateTempScript(t *testing.T) {
 	}
 	defer os.Remove(scriptPath)
 
-	f, err := ioutil.ReadFile(scriptPath)
+	f, err := os.ReadFile(scriptPath)
 	if err != nil {
 		t.Fatalf("couldn't read created inventoryfile: %s", err)
 	}

--- a/post-processor/googlecompute-import/post-processor.go
+++ b/post-processor/googlecompute-import/post-processor.go
@@ -13,7 +13,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -283,7 +282,7 @@ func (p PostProcessor) findTarballFromArtifact(artifact packersdk.Artifact) (io.
 }
 
 func FillFileContentBuffer(certOrKeyFile string) (*compute.FileContentBuffer, error) {
-	data, err := ioutil.ReadFile(certOrKeyFile)
+	data, err := os.ReadFile(certOrKeyFile)
 	if err != nil {
 		err := fmt.Errorf("Unable to read Certificate or Key file %s", certOrKeyFile)
 		return nil, err


### PR DESCRIPTION
Since the ioutil package is deprecated, we update all the instances in which it is used to replace them with the preferred methods of executing those functions.