### PR TITLE
Fix zone or region detection regex

### DIFF
--- a/lib/common/block_device.go
+++ b/lib/common/block_device.go
@@ -245,7 +245,7 @@ func GetRegionFromZone(zone string) (string, error) {
 	return matches[1], nil
 }
 
-var zoneRegexp = regexp.MustCompile("^[a-z]+-[a-z]+[0-9]-[a-z]$")
+var zoneRegexp = regexp.MustCompile("^[a-z]+-[a-z]+[0-9]{1,2}-[a-z]$")
 
 func IsZoneARegion(zone string) bool {
 	return !zoneRegexp.MatchString(zone)


### PR DESCRIPTION
Currently, there are some zones (a very few but still) in GCP that are not conforming to that regular expression due to having two digits in the region name, before the zone suffix, i.e. europe-west10.

That PR is to allow both variations to be supported, otherwise a disk is not properly removed when an instance is being removed, and has to be deleted manually, as the script treats the value as region name not the zone.