### PR TITLE
lib: add hyperdisk to supported volume types

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -651,8 +651,13 @@ source "googlecompute" "example" {
   * pd_balanced: persistent, SSD-backed disk
   * pd_ssd: persistent, SSD-backed disk, with extra performance guarantees
   * pd_extreme: persistent, fastest SSD-backed disk, with custom IOPS
+  * hyperdisk-balanced: persistent hyperdisk volume, bootable
+  * hyperdisk-extreme: persistent hyperdisk volume, optimised for performance
+  * hyperdisk-ml: persistent, shareable, hyperdisk volume, highest throughput
+  * hyperdisk-throughput: persistent hyperdisk volume with flexible throughput
   
   For details on the different types, refer to: https://cloud.google.com/compute/docs/disks#disk-types
+  For more information on hyperdisk volumes, refer to: https://cloud.google.com/compute/docs/disks/hyperdisks#throughput
 
 <!-- End of code generated from the comments of the BlockDevice struct in lib/common/block_device.go; -->
 

--- a/docs-partials/lib/common/BlockDevice-required.mdx
+++ b/docs-partials/lib/common/BlockDevice-required.mdx
@@ -12,7 +12,12 @@
   * pd_balanced: persistent, SSD-backed disk
   * pd_ssd: persistent, SSD-backed disk, with extra performance guarantees
   * pd_extreme: persistent, fastest SSD-backed disk, with custom IOPS
+  * hyperdisk-balanced: persistent hyperdisk volume, bootable
+  * hyperdisk-extreme: persistent hyperdisk volume, optimised for performance
+  * hyperdisk-ml: persistent, shareable, hyperdisk volume, highest throughput
+  * hyperdisk-throughput: persistent hyperdisk volume with flexible throughput
   
   For details on the different types, refer to: https://cloud.google.com/compute/docs/disks#disk-types
+  For more information on hyperdisk volumes, refer to: https://cloud.google.com/compute/docs/disks/hyperdisks#throughput
 
 <!-- End of code generated from the comments of the BlockDevice struct in lib/common/block_device.go; -->


### PR DESCRIPTION
Hyperdisks are another volume type with high-performance compared to other persistent options.
Since they weren't supported by the builder, we add those volume types to the configuration so users can provision their volumes with those.