### PR TITLE
builder: add deeplearning-platform-release project (issue #229)

### DIFF
--- a/lib/common/driver_gce.go
+++ b/lib/common/driver_gce.go
@@ -435,6 +435,7 @@ func (d *driverGCE) GetImage(name string, fromFamily bool) (*Image, error) {
 		"opensuse-cloud",
 		"ubuntu-os-pro-cloud",
 		"ml-images",
+		"deeplearning-platform-release",
 	}
 	return d.GetImageFromProjects(projects, name, fromFamily)
 }


### PR DESCRIPTION
Similar to the issue/changes described in https://github.com/hashicorp/packer-plugin-googlecompute/pull/192, this adds support for pulling source images from the `deeplearning-platform-release` [project](https://cloud.google.com/deep-learning-vm/docs/images#listing-versions).

Closes #229 
