### PR TITLE
[FEAT] bump post-processor worker to debian 12

### DIFF
--- a/post-processor/googlecompute-export/post-processor.go
+++ b/post-processor/googlecompute-export/post-processor.go
@@ -181,7 +181,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		Network:              p.config.Network,
 		NetworkProjectId:     builderProjectId,
 		StateTimeout:         5 * time.Minute,
-		SourceImageFamily:    "debian-9-worker",
+		SourceImageFamily:    "debian-12-worker",
 		SourceImageProjectId: []string{"compute-image-tools"},
 		Subnetwork:           p.config.Subnetwork,
 		Zone:                 p.config.Zone,


### PR DESCRIPTION
This MR simply bump the debian worker used in the exporter to a present worker. 

Another solution would be to ensure a default image and allow user to override it. Since it's my first time with Go and this module I'm proposing to resolve this blocking issue the simpler way and maybe reopen an issue and work on it later on.

Closes #243 


