### PR TITLE
BUG: Fixed the UseOsLogin param to use Trilean instead

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -297,7 +297,7 @@ builder.
 - `use_internal_ip` (bool) - If true, use the instance's internal IP instead of its external IP
   during building.
 
-- `use_os_login` (bool) - If true, OSLogin will be used to manage SSH access to the compute instance by
+- `use_os_login` (boolean) - If true, OSLogin will be used to manage SSH access to the compute instance by
   dynamically importing a temporary SSH key to the Google account's login profile,
   and setting the `enable-oslogin` to `TRUE` in the instance metadata.
   Optionally, `use_os_login` can be used with an existing `ssh_username` and `ssh_private_key_file`

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -335,7 +335,7 @@ type Config struct {
 	//  000000000000000000000000000000000000000000000000000000000000000a:
 	//    fingerprint: 000000000000000000000000000000000000000000000000000000000000000a
 	//```
-	UseOSLogin bool `mapstructure:"use_os_login" required:"false"`
+	UseOSLogin config.Trilean `mapstructure:"use_os_login" required:"false"`
 	// The time to wait between the creation of the instance used to create the image,
 	// and the addition of SSH configuration, including SSH keys, to that instance.
 	// The delay is intended to protect packer from anything in the instance boot

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -79,8 +79,12 @@ func (c *Config) createInstanceMetadata(sourceImage *common.Image, sshPublicKey 
 
 	// If UseOSLogin is true, force `enable-oslogin` in metadata
 	// In the event that `enable-oslogin` is not enabled at project level
-	if c.UseOSLogin {
+	if c.UseOSLogin.True() {
 		instanceMetadataNoSSHKeys[EnableOSLoginKey] = "TRUE"
+	}
+
+	if c.UseOSLogin.False() {
+		instanceMetadataNoSSHKeys[EnableOSLoginKey] = "FALSE"
 	}
 
 	for key, value := range c.MetadataFiles {

--- a/builder/googlecompute/step_import_os_login_ssh_key.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	metadata "cloud.google.com/go/compute/metadata"
@@ -34,7 +35,12 @@ func (s *StepImportOSLoginSSHKey) Run(ctx context.Context, state multistep.State
 	driver := state.Get("driver").(common.Driver)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	if !config.UseOSLogin {
+	osLoginEnabledAtProject, err := driver.GetProjectMetadata(config.Zone, EnableOSLoginKey)
+	if err != nil {
+		log.Printf("failed to get project metadata: %s", err)
+	}
+
+	if config.UseOSLogin.False() || (config.UseOSLogin.ToBoolPointer() == nil && strings.EqualFold(osLoginEnabledAtProject, "false")) {
 		return multistep.ActionContinue
 	}
 

--- a/builder/googlecompute/step_import_os_login_ssh_key_test.go
+++ b/builder/googlecompute/step_import_os_login_ssh_key_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	configsdk "github.com/hashicorp/packer-plugin-sdk/template/config"
 	"google.golang.org/api/oauth2/v2"
 )
 
@@ -21,7 +22,7 @@ func TestStepImportOSLoginSSHKey_impl(t *testing.T) {
 func TestStepImportOSLoginSSHKey(t *testing.T) {
 	tt := []struct {
 		Name           string
-		UseOSLogin     bool
+		UseOSLogin     configsdk.Trilean
 		ExpectedEmail  string
 		ExpectedAction multistep.StepAction
 		PubKeyExpected bool
@@ -32,7 +33,7 @@ func TestStepImportOSLoginSSHKey(t *testing.T) {
 		},
 		{
 			Name:           "UseOSLoginWithAccountFile",
-			UseOSLogin:     true,
+			UseOSLogin:     configsdk.TriTrue,
 			ExpectedAction: multistep.ActionContinue,
 			ExpectedEmail:  "raffi-compute@developer.gserviceaccount.com",
 			PubKeyExpected: true,
@@ -83,7 +84,7 @@ func TestStepImportOSLoginSSHKey_withAccountFile(t *testing.T) {
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
+	config.UseOSLogin = configsdk.TriTrue
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
@@ -116,7 +117,7 @@ func TestStepImportOSLoginSSHKey_withNoAccountFile(t *testing.T) {
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
+	config.UseOSLogin = configsdk.TriTrue
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
@@ -149,7 +150,7 @@ func TestStepImportOSLoginSSHKey_withGCEAndNoAccount(t *testing.T) {
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
+	config.UseOSLogin = configsdk.TriTrue
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
@@ -186,7 +187,7 @@ func TestStepImportOSLoginSSHKey_withGCEAndAccount(t *testing.T) {
 	defer step.Cleanup(state)
 
 	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
+	config.UseOSLogin = configsdk.TriTrue
 	config.Comm.SSHPublicKey = []byte{'k', 'e', 'y'}
 
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
@@ -221,7 +222,7 @@ func TestStepImportOSLoginSSHKey_withPrivateSSHKey(t *testing.T) {
 	defer os.Remove(pkey)
 
 	config := state.Get("config").(*Config)
-	config.UseOSLogin = true
+	config.UseOSLogin = configsdk.TriTrue
 	config.Comm.SSHPrivateKeyFile = pkey
 
 	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -243,7 +243,7 @@
 - `use_internal_ip` (bool) - If true, use the instance's internal IP instead of its external IP
   during building.
 
-- `use_os_login` (bool) - If true, OSLogin will be used to manage SSH access to the compute instance by
+- `use_os_login` (boolean) - If true, OSLogin will be used to manage SSH access to the compute instance by
   dynamically importing a temporary SSH key to the Google account's login profile,
   and setting the `enable-oslogin` to `TRUE` in the instance metadata.
   Optionally, `use_os_login` can be used with an existing `ssh_username` and `ssh_private_key_file`

--- a/lib/common/driver.go
+++ b/lib/common/driver.go
@@ -50,6 +50,9 @@ type Driver interface {
 	// is true, name designates an image family instead of a particular image.
 	GetImageFromProject(project, name string, fromFamily bool) (*Image, error)
 
+	// GetProjectMetadata gets a metadata variable for the project.
+	GetProjectMetadata(zone, key string) (string, error)
+
 	// GetInstanceMetadata gets a metadata variable for the instance, name.
 	GetInstanceMetadata(zone, name, key string) (string, error)
 

--- a/lib/common/driver_gce.go
+++ b/lib/common/driver_gce.go
@@ -484,6 +484,21 @@ func (d *driverGCE) GetImageFromProject(project, name string, fromFamily bool) (
 	}
 }
 
+func (d *driverGCE) GetProjectMetadata(zone, key string) (string, error) {
+	project, err := d.service.Projects.Get(d.projectId).Do()
+	if err != nil {
+		return "", err
+	}
+
+	for _, item := range project.CommonInstanceMetadata.Items {
+		if item.Key == key {
+			return *item.Value, nil
+		}
+	}
+
+	return "", fmt.Errorf("Project metadata key, %s, not found.", key)
+}
+
 func (d *driverGCE) GetInstanceMetadata(zone, name, key string) (string, error) {
 	instance, err := d.service.Instances.Get(d.projectId, zone, name).Do()
 	if err != nil {

--- a/lib/common/driver_mock.go
+++ b/lib/common/driver_mock.go
@@ -67,6 +67,11 @@ type DriverMock struct {
 	GetInstanceMetadataResult string
 	GetInstanceMetadataErr    error
 
+	GetProjectMetadataZone   string
+	GetProjectMetadataKey    string
+	GetProjectMetadataResult string
+	GetProjectMetadataErr    error
+
 	GetTokenInfoResult *oauth2_svc.Tokeninfo
 	GetTokenInfoErr    error
 
@@ -274,6 +279,12 @@ func (d *DriverMock) GetImageFromProject(project, name string, fromFamily bool) 
 	d.GetImageFromProjectName = name
 	d.GetImageFromProjectFromFamily = fromFamily
 	return d.GetImageFromProjectResult, d.GetImageFromProjectErr
+}
+
+func (d *DriverMock) GetProjectMetadata(zone, key string) (string, error) {
+	d.GetProjectMetadataZone = zone
+	d.GetProjectMetadataKey = key
+	return d.GetProjectMetadataResult, d.GetProjectMetadataErr
 }
 
 func (d *DriverMock) GetInstanceMetadata(zone, name, key string) (string, error) {


### PR DESCRIPTION
## Use case
This PR fixes a bug where packer did not respect the `use_os_login` param when set to false. This caused issue when osLogin was enabled at project level and one wanted to disable it at an instance level.

## Changes
This PR updates the `use_os_login` param to be a trilean instead of a boolean and added a condition to set the flag to False as well.
Also added a function to fetch Project's metadata to check the status of a flag at project level, i.e. `use_os_login` status.

## Testing
This was tested by enabling OsLogin at Project level and setting the `use_os_login` flag as true and false and by removing the flag.

To verify the change, when doing an SSH into the machine, the user name should be your mail in case of oslogin enabled and it should be your name in case it is disabled.

Closes #241 