### PR TITLE
FEAT: Added fields to set Lifecycle Properties to an Image

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -350,6 +350,19 @@ builder.
   during it's creation.
   Example value: `5m`.
 
+- `deprecate_at` (string) - Time when the image is considered as deprecated.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
+- `obsolete_at` (string) - Time when the image is considered obsolete.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
+- `delete_at` (string) - Time when the image is scheduled for deletion.
+  GCP won’t auto-delete it, but it should be cleaned up manually.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
 <!-- End of code generated from the comments of the Config struct in builder/googlecompute/config.go; -->
 
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -349,6 +349,22 @@ type Config struct {
 	// Example: `"us-central1-a"`
 	Zone string `mapstructure:"zone" required:"true"`
 
+	// Time when the image is considered as deprecated.
+	// In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+	// You can’t specify a date in the past.
+	DeprecateAt string `mapstructure:"deprecate_at" required:"false"`
+
+	// Time when the image is considered obsolete.
+	// In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+	// You can’t specify a date in the past.
+	ObsoleteAt string `mapstructure:"obsolete_at" required:"false"`
+
+	// Time when the image is scheduled for deletion.
+	// GCP won’t auto-delete it, but it should be cleaned up manually.
+	// In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+	// You can’t specify a date in the past.
+	DeleteAt string `mapstructure:"delete_at" required:"false"`
+
 	ctx                interpolate.Context
 	imageSourceDisk    string
 	imageAlreadyExists bool

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -132,6 +132,9 @@ type FlatConfig struct {
 	UseOSLogin                   *bool                             `mapstructure:"use_os_login" required:"false" cty:"use_os_login" hcl:"use_os_login"`
 	WaitToAddSSHKeys             *string                           `mapstructure:"wait_to_add_ssh_keys" cty:"wait_to_add_ssh_keys" hcl:"wait_to_add_ssh_keys"`
 	Zone                         *string                           `mapstructure:"zone" required:"true" cty:"zone" hcl:"zone"`
+	DeprecateAt                  *string                           `mapstructure:"deprecate_at" required:"false" cty:"deprecate_at" hcl:"deprecate_at"`
+	ObsoleteAt                   *string                           `mapstructure:"obsolete_at" required:"false" cty:"obsolete_at" hcl:"obsolete_at"`
+	DeleteAt                     *string                           `mapstructure:"delete_at" required:"false" cty:"delete_at" hcl:"delete_at"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -267,6 +270,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"use_os_login":                    &hcldec.AttrSpec{Name: "use_os_login", Type: cty.Bool, Required: false},
 		"wait_to_add_ssh_keys":            &hcldec.AttrSpec{Name: "wait_to_add_ssh_keys", Type: cty.String, Required: false},
 		"zone":                            &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
+		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},
+		"obsolete_at":                     &hcldec.AttrSpec{Name: "obsolete_at", Type: cty.String, Required: false},
+		"delete_at":                       &hcldec.AttrSpec{Name: "delete_at", Type: cty.String, Required: false},
 	}
 	return s
 }

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -296,4 +296,17 @@
   during it's creation.
   Example value: `5m`.
 
+- `deprecate_at` (string) - Time when the image is considered as deprecated.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
+- `obsolete_at` (string) - Time when the image is considered obsolete.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
+- `delete_at` (string) - Time when the image is scheduled for deletion.
+  GCP won’t auto-delete it, but it should be cleaned up manually.
+  In UTC, in the following RFC3339 format: YYYY-MM-DDTHH:MM:SSZ.
+  You can’t specify a date in the past.
+
 <!-- End of code generated from the comments of the Config struct in builder/googlecompute/config.go; -->

--- a/lib/common/driver.go
+++ b/lib/common/driver.go
@@ -24,6 +24,10 @@ type Driver interface {
 	// Engine.
 	CreateImage(project string, imageSpec *compute.Image) (<-chan *Image, <-chan error)
 
+	// SetImageDeprecationStatus sets the deprecation, obsolete and deletion date
+	// for the image with the given name.
+	SetImageDeprecationStatus(project, name string, deprecationStatus *compute.DeprecationStatus) error
+
 	// DeleteImage deletes the image with the given name.
 	DeleteImage(project, name string) <-chan error
 

--- a/lib/common/driver_gce.go
+++ b/lib/common/driver_gce.go
@@ -229,6 +229,14 @@ func (d *driverGCE) CreateImage(project string, imageSpec *compute.Image) (<-cha
 	return imageCh, errCh
 }
 
+func (d *driverGCE) SetImageDeprecationStatus(project, name string, deprecationStatus *compute.DeprecationStatus) error {
+	if deprecationStatus == nil {
+		return errors.New("deprecationStatus cannot be nil")
+	}
+	_, err := d.service.Images.Deprecate(project, name, deprecationStatus).Do()
+	return err
+}
+
 func (d *driverGCE) DeleteImage(project, name string) <-chan error {
 	errCh := make(chan error, 1)
 	op, err := d.service.Images.Delete(project, name).Do()

--- a/lib/common/driver_mock.go
+++ b/lib/common/driver_mock.go
@@ -26,6 +26,10 @@ type DriverMock struct {
 	CreateImageErrCh          <-chan error
 	CreateImageResultCh       <-chan *Image
 
+	DeprecatedProjectName string
+	DeprecatedImageName   string
+	DeprecatedImageStatus *compute.DeprecationStatus
+
 	DeleteProjectId  string
 	DeleteImageName  string
 	DeleteImageErrCh <-chan error
@@ -179,6 +183,13 @@ func (d *DriverMock) CreateImageFromRaw(
 	imageArchitecture string,
 ) (<-chan *Image, <-chan error) {
 	return nil, nil
+}
+
+func (d *DriverMock) SetImageDeprecationStatus(project, name string, deprecationStatus *compute.DeprecationStatus) error {
+	d.DeprecatedProjectName = project
+	d.DeprecatedImageName = name
+	d.DeprecatedImageStatus = deprecationStatus
+	return nil
 }
 
 func (d *DriverMock) DeleteImage(project, name string) <-chan error {


### PR DESCRIPTION
Adding new fields `deprecate_at`, `obsolete_at` and `delete_at` to the template to enable users to set these lifecycle properties to an Image created by Packer.

Closes #245

