### PR TITLE
Adds configurable OS Login SSH username support

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -343,6 +343,26 @@ builder.
 
 - `network_ip` (string) - The network IP address reserved to use for the launched instance.
 
+- `oslogin_ssh_username` (string) - OSLoginSSHUsername specifies the username to be used with OS Login when importing the SSH public key.
+  
+  This value controls which username is associated with the SSH key during provisioning.
+  
+  Valid values:
+    - "" or "__auto__": Use the username from the OS Login profile as-is,
+                        unless it starts with "sa_" or "ext_" (in which case it's used unchanged).
+    - "__external__": Normalize the profile username (lowercase, replace special chars, truncate to 32),
+                      then prepend "ext_".
+  
+  Alternatively, you may provide an explicit username string.
+  
+  Example:
+    oslogin_ssh_username = "__external__"
+  
+  This is useful when authenticating with an external (federated) identity, where GCP prepends
+  "ext_" to the canonical username in the browser, but omits it when using ADC in Packer.
+  
+  Note: Invalid or unsupported values will result in an error during provisioning.
+
 - `wait_to_add_ssh_keys` (duration string | ex: "1h5m2s") - The time to wait between the creation of the instance used to create the image,
   and the addition of SSH configuration, including SSH keys, to that instance.
   The delay is intended to protect packer from anything in the instance boot

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -340,6 +340,26 @@ type Config struct {
 	UseOSLogin config.Trilean `mapstructure:"use_os_login" required:"false"`
 	// The network IP address reserved to use for the launched instance.
 	NetworkIP string `mapstructure:"network_ip" required:"false"`
+	// OSLoginSSHUsername specifies the username to be used with OS Login when importing the SSH public key.
+	//
+	// This value controls which username is associated with the SSH key during provisioning.
+	//
+	// Valid values:
+	//   - "" or "__auto__": Use the username from the OS Login profile as-is,
+	//                       unless it starts with "sa_" or "ext_" (in which case it's used unchanged).
+	//   - "__external__": Normalize the profile username (lowercase, replace special chars, truncate to 32),
+	//                     then prepend "ext_".
+	//
+	// Alternatively, you may provide an explicit username string.
+	//
+	// Example:
+	//   oslogin_ssh_username = "__external__"
+	//
+	// This is useful when authenticating with an external (federated) identity, where GCP prepends
+	// "ext_" to the canonical username in the browser, but omits it when using ADC in Packer.
+	//
+	// Note: Invalid or unsupported values will result in an error during provisioning.
+	OSLoginSSHUsername string `mapstructure:"oslogin_ssh_username" required:"false"`
 	// The time to wait between the creation of the instance used to create the image,
 	// and the addition of SSH configuration, including SSH keys, to that instance.
 	// The delay is intended to protect packer from anything in the instance boot
@@ -369,9 +389,10 @@ type Config struct {
 	// You can’t specify a date in the past.
 	DeleteAt string `mapstructure:"delete_at" required:"false"`
 
-	ctx                interpolate.Context
-	imageSourceDisk    string
-	imageAlreadyExists bool
+	ctx                  interpolate.Context
+	imageSourceDisk      string
+	imageAlreadyExists   bool
+	loginProfileUsername string
 }
 
 func (c *Config) Prepare(raws ...interface{}) ([]string, error) {

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -131,6 +131,7 @@ type FlatConfig struct {
 	UseInternalIP                *bool                             `mapstructure:"use_internal_ip" required:"false" cty:"use_internal_ip" hcl:"use_internal_ip"`
 	UseOSLogin                   *bool                             `mapstructure:"use_os_login" required:"false" cty:"use_os_login" hcl:"use_os_login"`
 	NetworkIP                    *string                           `mapstructure:"network_ip" required:"false" cty:"network_ip" hcl:"network_ip"`
+	OSLoginSSHUsername           *string                           `mapstructure:"oslogin_ssh_username" required:"false" cty:"oslogin_ssh_username" hcl:"oslogin_ssh_username"`
 	WaitToAddSSHKeys             *string                           `mapstructure:"wait_to_add_ssh_keys" cty:"wait_to_add_ssh_keys" hcl:"wait_to_add_ssh_keys"`
 	Zone                         *string                           `mapstructure:"zone" required:"true" cty:"zone" hcl:"zone"`
 	DeprecateAt                  *string                           `mapstructure:"deprecate_at" required:"false" cty:"deprecate_at" hcl:"deprecate_at"`
@@ -270,6 +271,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"use_internal_ip":                 &hcldec.AttrSpec{Name: "use_internal_ip", Type: cty.Bool, Required: false},
 		"use_os_login":                    &hcldec.AttrSpec{Name: "use_os_login", Type: cty.Bool, Required: false},
 		"network_ip":                      &hcldec.AttrSpec{Name: "network_ip", Type: cty.String, Required: false},
+		"oslogin_ssh_username":            &hcldec.AttrSpec{Name: "oslogin_ssh_username", Type: cty.String, Required: false},
 		"wait_to_add_ssh_keys":            &hcldec.AttrSpec{Name: "wait_to_add_ssh_keys", Type: cty.String, Required: false},
 		"zone":                            &hcldec.AttrSpec{Name: "zone", Type: cty.String, Required: false},
 		"deprecate_at":                    &hcldec.AttrSpec{Name: "deprecate_at", Type: cty.String, Required: false},

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -46,7 +46,7 @@ func (c *Config) createInstanceMetadata(sourceImage *common.Image, sshPublicKey 
 	if c.Comm.SSHPrivateKeyFile == "" && sshPublicKey != "" {
 		sshMetaKey := "ssh-keys"
 		sshPublicKey = strings.TrimSuffix(sshPublicKey, "\n")
-		sshKeys := fmt.Sprintf("%s:%s %s", c.Comm.SSHUsername, sshPublicKey, c.Comm.SSHUsername)
+		sshKeys := fmt.Sprintf("%s:%s %s", c.loginProfileUsername, sshPublicKey, c.loginProfileUsername)
 		if confSSHKeys, exists := instanceMetadataSSHKeys[sshMetaKey]; exists {
 			sshKeys = fmt.Sprintf("%s\n%s", sshKeys, confSSHKeys)
 		}

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -289,6 +289,26 @@
 
 - `network_ip` (string) - The network IP address reserved to use for the launched instance.
 
+- `oslogin_ssh_username` (string) - OSLoginSSHUsername specifies the username to be used with OS Login when importing the SSH public key.
+  
+  This value controls which username is associated with the SSH key during provisioning.
+  
+  Valid values:
+    - "" or "__auto__": Use the username from the OS Login profile as-is,
+                        unless it starts with "sa_" or "ext_" (in which case it's used unchanged).
+    - "__external__": Normalize the profile username (lowercase, replace special chars, truncate to 32),
+                      then prepend "ext_".
+  
+  Alternatively, you may provide an explicit username string.
+  
+  Example:
+    oslogin_ssh_username = "__external__"
+  
+  This is useful when authenticating with an external (federated) identity, where GCP prepends
+  "ext_" to the canonical username in the browser, but omits it when using ADC in Packer.
+  
+  Note: Invalid or unsupported values will result in an error during provisioning.
+
 - `wait_to_add_ssh_keys` (duration string | ex: "1h5m2s") - The time to wait between the creation of the instance used to create the image,
   and the addition of SSH configuration, including SSH keys, to that instance.
   The delay is intended to protect packer from anything in the instance boot


### PR DESCRIPTION
Introduces an option, `oslogin_ssh_username`, to customize the SSH username used with OS Login, enabling explicit control or normalization for federated identities. Improves compatibility across authentication methods and documents the new setting for users.

The option supports the following sentinel values:
- `__auto__` [default]: Fetches the username from the OS Login profile from GCP.
- `__external__`: Adds an `ext_` to the login profile username and truncates it to 32 chars.


Closes #254 

