### PR TITLE
BUG: Fixed a bug for EnableOsLogin field in Metadata

### DIFF
--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -414,6 +414,10 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 	var warnings []string
 	var errs error
 
+	if v, exists := c.Metadata[EnableOSLoginKey]; exists && c.UseOSLogin.ToBoolPointer() == nil {
+		c.UseOSLogin, _ = config.TrileanFromString(v)
+	}
+
 	for i, bd := range c.ExtraBlockDevices {
 		err := bd.Prepare()
 		if err != nil {


### PR DESCRIPTION
Fixed a bug introduced in the last release, where Packer was not considering the `enable-oslogin` param being passed in the `metadata`.

Closes #281 