### PR TITLE
Add support for Secure Tags

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -312,6 +312,8 @@ builder.
 
 - `tags` ([]string) - Assign network tags to apply firewall rules to VM instance.
 
+- `resource_manager_tags` (map[string]string) - Assign Secure Tags to apply firewall rules to VM instance.
+
 - `use_internal_ip` (bool) - If true, use the instance's internal IP instead of its external IP
   during building.
 

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -310,6 +310,8 @@ type Config struct {
 	Subnetwork string `mapstructure:"subnetwork" required:"false"`
 	// Assign network tags to apply firewall rules to VM instance.
 	Tags []string `mapstructure:"tags" required:"false"`
+	// Assign Secure Tags to apply firewall rules to VM instance.
+	ResourceManagerTags map[string]string `mapstructure:"resource_manager_tags" required:"false"`
 	// If true, use the instance's internal IP instead of its external IP
 	// during building.
 	UseInternalIP bool `mapstructure:"use_internal_ip" required:"false"`

--- a/builder/googlecompute/config.hcl2spec.go
+++ b/builder/googlecompute/config.hcl2spec.go
@@ -134,6 +134,7 @@ type FlatConfig struct {
 	WrapStartupScriptFile        *bool                             `mapstructure:"wrap_startup_script" required:"false" cty:"wrap_startup_script" hcl:"wrap_startup_script"`
 	Subnetwork                   *string                           `mapstructure:"subnetwork" required:"false" cty:"subnetwork" hcl:"subnetwork"`
 	Tags                         []string                          `mapstructure:"tags" required:"false" cty:"tags" hcl:"tags"`
+	ResourceManagerTags          map[string]string                 `mapstructure:"resource_manager_tags" required:"false" cty:"resource_manager_tags" hcl:"resource_manager_tags"`
 	UseInternalIP                *bool                             `mapstructure:"use_internal_ip" required:"false" cty:"use_internal_ip" hcl:"use_internal_ip"`
 	UseOSLogin                   *bool                             `mapstructure:"use_os_login" required:"false" cty:"use_os_login" hcl:"use_os_login"`
 	NetworkIP                    *string                           `mapstructure:"network_ip" required:"false" cty:"network_ip" hcl:"network_ip"`
@@ -283,6 +284,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"wrap_startup_script":             &hcldec.AttrSpec{Name: "wrap_startup_script", Type: cty.Bool, Required: false},
 		"subnetwork":                      &hcldec.AttrSpec{Name: "subnetwork", Type: cty.String, Required: false},
 		"tags":                            &hcldec.AttrSpec{Name: "tags", Type: cty.List(cty.String), Required: false},
+		"resource_manager_tags":           &hcldec.AttrSpec{Name: "resource_manager_tags", Type: cty.Map(cty.String), Required: false},
 		"use_internal_ip":                 &hcldec.AttrSpec{Name: "use_internal_ip", Type: cty.Bool, Required: false},
 		"use_os_login":                    &hcldec.AttrSpec{Name: "use_os_login", Type: cty.Bool, Required: false},
 		"network_ip":                      &hcldec.AttrSpec{Name: "network_ip", Type: cty.String, Required: false},

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -211,6 +211,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		Scopes:                       c.Scopes,
 		Subnetwork:                   c.Subnetwork,
 		Tags:                         c.Tags,
+		ResourceManagerTags:          c.ResourceManagerTags,
 		Zone:                         c.Zone,
 		NetworkIP:                    c.NetworkIP,
 	})

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -258,6 +258,8 @@
 
 - `tags` ([]string) - Assign network tags to apply firewall rules to VM instance.
 
+- `resource_manager_tags` (map[string]string) - Assign Secure Tags to apply firewall rules to VM instance.
+
 - `use_internal_ip` (bool) - If true, use the instance's internal IP instead of its external IP
   during building.
 

--- a/lib/common/driver_gce.go
+++ b/lib/common/driver_gce.go
@@ -742,6 +742,11 @@ func (d *driverGCE) RunInstance(c *InstanceConfig) (<-chan error, error) {
 			Items: c.Tags,
 		},
 	}
+	if len(c.ResourceManagerTags) > 0 {
+		instance.Params = &compute.InstanceParams{
+			ResourceManagerTags: c.ResourceManagerTags,
+		}
+	}
 
 	if c.MaxRunDurationInSeconds > 0 {
 		log.Printf("[DEBUG] setting max run duration to %d seconds", c.MaxRunDurationInSeconds)

--- a/lib/common/instance.go
+++ b/lib/common/instance.go
@@ -37,6 +37,8 @@ type InstanceConfig struct {
 	Scopes                       []string
 	Subnetwork                   string
 	Tags                         []string
-	Zone                         string
-	NetworkIP                    string
+	ResourceManagerTags          map[string]string
+
+	Zone      string
+	NetworkIP string
 }


### PR DESCRIPTION
### Description
What code changed, and why?

I've added support for specifying `resource_manager_tags` aka Secure Tags. For customers using restrictive Firewall Policies, this is required to spin up the instance with a Firewall Tag (note, not network tag).

FYI: I've tested this locally and while I'd love add a test for this - it requires so much resources around it that the test would take 1+ hours easily and require a lot of access (NGFW provisioning, firewall endpoints, etc etc).

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

Probably not needed. 

### Changes to Security Controls

None required, net new stuff.
