### PR TITLE
UEFI_COMPATIBLE is not needed when passing in image guest OS features

### DIFF
--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -850,9 +850,7 @@ func testConfig(t *testing.T) (config map[string]interface{}, tempAccountFile st
 		"image_licenses": []string{
 			"test-license",
 		},
-		"image_guest_os_features": []string{
-			"UEFI_COMPATIBLE",
-		},
+		"image_guest_os_features": []string{},
 		"image_storage_locations": []string{
 			"us-east1",
 		},

--- a/builder/googlecompute/step_create_image.go
+++ b/builder/googlecompute/step_create_image.go
@@ -58,7 +58,7 @@ func (s *StepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 		})
 	}
 
-	shieldedVMStateConfig, shieldErr := common.CreateShieldedVMStateConfig(config.ImageGuestOsFeatures, config.ImagePlatformKey, config.ImageKeyExchangeKey, config.ImageSignaturesDB, config.ImageForbiddenSignaturesDB)
+	shieldedVMStateConfig, shieldErr := common.CreateShieldedVMStateConfig(config.ImagePlatformKey, config.ImageKeyExchangeKey, config.ImageSignaturesDB, config.ImageForbiddenSignaturesDB)
 
 	if shieldErr != nil {
 		ui.Error(shieldErr.Error())

--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -93,3 +93,47 @@ func TestStepCreateImage_setsDeprecationFields(t *testing.T) {
 	assert.Equal(t, c.DeleteAt, d.DeprecatedImageStatus.Deleted, "DeleteAt mismatch")
 	assert.Contains(t, []string{"DEPRECATED", "ACTIVE"}, d.DeprecatedImageStatus.State, "State should be DEPRECATED or ACTIVE")
 }
+
+func TestStepCreateImageNonUEFI_image(t *testing.T) {
+	state := testState(t)
+	step := new(StepCreateImage)
+	defer step.Cleanup(state)
+
+	c := state.Get("config").(*Config)
+	c.ImageGuestOsFeatures = []string{}
+
+	// run the step
+	action := step.Run(context.Background(), state)
+	assert.Equal(t, action, multistep.ActionContinue, "Step did not pass.")
+
+	uncastImage, ok := state.GetOk("image")
+	assert.True(t, ok, "State does not have resulting image.")
+	image, ok := uncastImage.(*common.Image)
+	assert.True(t, ok, "Image in state is not an Image.")
+
+	assert.Len(t, image.ShieldedInstanceInitialState.Keks, 1)
+	assert.Len(t, image.ShieldedInstanceInitialState.Dbs, 1)
+	assert.Len(t, image.ShieldedInstanceInitialState.Dbxs, 1)
+}
+
+func TestStepCreateImageUEFI_image(t *testing.T) {
+	state := testState(t)
+	step := new(StepCreateImage)
+	defer step.Cleanup(state)
+
+	c := state.Get("config").(*Config)
+	c.ImageGuestOsFeatures = []string{"UEFI_COMPATIBLE"}
+
+	// run the step
+	action := step.Run(context.Background(), state)
+	assert.Equal(t, action, multistep.ActionContinue, "Step did not pass.")
+
+	uncastImage, ok := state.GetOk("image")
+	assert.True(t, ok, "State does not have resulting image.")
+	image, ok := uncastImage.(*common.Image)
+	assert.True(t, ok, "Image in state is not an Image.")
+
+	assert.Len(t, image.ShieldedInstanceInitialState.Keks, 1)
+	assert.Len(t, image.ShieldedInstanceInitialState.Dbs, 1)
+	assert.Len(t, image.ShieldedInstanceInitialState.Dbxs, 1)
+}

--- a/lib/common/shielded_vms.go
+++ b/lib/common/shielded_vms.go
@@ -33,40 +33,35 @@ func FillFileContentBuffer(certOrKeyFile string) (*compute.FileContentBuffer, er
 	return shield, nil
 }
 
-func CreateShieldedVMStateConfig(imageGuestOsFeatures []string, imagePlatformKey string, imageKeyExchangeKey []string, imageSignaturesDB []string, imageForbiddenSignaturesDB []string) (*compute.InitialStateConfig, error) {
+func CreateShieldedVMStateConfig(imagePlatformKey string, imageKeyExchangeKey []string, imageSignaturesDB []string, imageForbiddenSignaturesDB []string) (*compute.InitialStateConfig, error) {
 	shieldedVMStateConfig := &compute.InitialStateConfig{}
-	for _, v := range imageGuestOsFeatures {
-		if v == "UEFI_COMPATIBLE" {
-			if imagePlatformKey != "" {
-				shieldedData, err := FillFileContentBuffer(imagePlatformKey)
-				if err != nil {
-					return nil, err
-				}
-				shieldedVMStateConfig.Pk = shieldedData
-			}
-			for _, v := range imageKeyExchangeKey {
-				shieldedData, err := FillFileContentBuffer(v)
-				if err != nil {
-					return nil, err
-				}
-				shieldedVMStateConfig.Keks = append(shieldedVMStateConfig.Keks, shieldedData)
-			}
-			for _, v := range imageSignaturesDB {
-				shieldedData, err := FillFileContentBuffer(v)
-				if err != nil {
-					return nil, err
-				}
-				shieldedVMStateConfig.Dbs = append(shieldedVMStateConfig.Dbs, shieldedData)
-			}
-			for _, v := range imageForbiddenSignaturesDB {
-				shieldedData, err := FillFileContentBuffer(v)
-				if err != nil {
-					return nil, err
-				}
-				shieldedVMStateConfig.Dbxs = append(shieldedVMStateConfig.Dbxs, shieldedData)
-			}
-
+	if imagePlatformKey != "" {
+		shieldedData, err := FillFileContentBuffer(imagePlatformKey)
+		if err != nil {
+			return nil, err
 		}
+		shieldedVMStateConfig.Pk = shieldedData
+	}
+	for _, v := range imageKeyExchangeKey {
+		shieldedData, err := FillFileContentBuffer(v)
+		if err != nil {
+			return nil, err
+		}
+		shieldedVMStateConfig.Keks = append(shieldedVMStateConfig.Keks, shieldedData)
+	}
+	for _, v := range imageSignaturesDB {
+		shieldedData, err := FillFileContentBuffer(v)
+		if err != nil {
+			return nil, err
+		}
+		shieldedVMStateConfig.Dbs = append(shieldedVMStateConfig.Dbs, shieldedData)
+	}
+	for _, v := range imageForbiddenSignaturesDB {
+		shieldedData, err := FillFileContentBuffer(v)
+		if err != nil {
+			return nil, err
+		}
+		shieldedVMStateConfig.Dbxs = append(shieldedVMStateConfig.Dbxs, shieldedData)
 	}
 	return shieldedVMStateConfig, nil
 }

--- a/post-processor/googlecompute-import/post-processor.go
+++ b/post-processor/googlecompute-import/post-processor.go
@@ -221,7 +221,7 @@ func (p *PostProcessor) PostProcess(ctx context.Context, ui packersdk.Ui, artifa
 		return nil, false, false, err
 	}
 
-	shieldedVMStateConfig, err := common.CreateShieldedVMStateConfig(p.config.ImageGuestOsFeatures, p.config.ImagePlatformKey, p.config.ImageKeyExchangeKey, p.config.ImageSignaturesDB, p.config.ImageForbiddenSignaturesDB)
+	shieldedVMStateConfig, err := common.CreateShieldedVMStateConfig(p.config.ImagePlatformKey, p.config.ImageKeyExchangeKey, p.config.ImageSignaturesDB, p.config.ImageForbiddenSignaturesDB)
 	if err != nil {
 		return nil, false, false, err
 	}


### PR DESCRIPTION
### Description

Remove the need to pass in `UEFI_COMPATIBLE` as a guest OS feature to pass Secure Boot.

### Resolved Issues

Closes https://github.com/hashicorp/packer-plugin-googlecompute/issues/332

### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

