### PR TITLE
fix: avoid sending empty ShieldedInstanceInitialState on image create

### DIFF
--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -117,11 +117,7 @@ func TestStepCreateImage_noSignatureInputsLeavesInitialStateNil(t *testing.T) {
 	action := step.Run(context.Background(), state)
 	assert.Equal(t, multistep.ActionContinue, action, "Step did not pass.")
 
-	assert.Nil(
-		t,
-		d.CreateImageSpec.ShieldedInstanceInitialState,
-		"shieldedInstanceInitialState must be nil so the source disk's initial state is inherited",
-	)
+	assert.Nil(t, d.CreateImageSpec.ShieldedInstanceInitialState, "shieldedInstanceInitialState must be nil so the source disk's initial state is inherited")
 }
 
 func TestStepCreateImageNonUEFI_image(t *testing.T) {

--- a/builder/googlecompute/step_create_image_test.go
+++ b/builder/googlecompute/step_create_image_test.go
@@ -94,6 +94,36 @@ func TestStepCreateImage_setsDeprecationFields(t *testing.T) {
 	assert.Contains(t, []string{"DEPRECATED", "ACTIVE"}, d.DeprecatedImageStatus.State, "State should be DEPRECATED or ACTIVE")
 }
 
+// Regression test: when no Secure Boot signature inputs are configured, the
+// image insert request must not include a shieldedInstanceInitialState field.
+// Sending an explicit (even empty) InitialStateConfig replaces the
+// PK/KEKs/db/dbx that would otherwise be inherited from the source disk and
+// causes Secure Boot to fail on VMs launched from the resulting image
+// (UEFI: "Status: Security Violation").
+func TestStepCreateImage_noSignatureInputsLeavesInitialStateNil(t *testing.T) {
+	state := testState(t)
+	step := new(StepCreateImage)
+	defer step.Cleanup(state)
+
+	c := state.Get("config").(*Config)
+	d := state.Get("driver").(*common.DriverMock)
+
+	// Clear all signature inputs supplied by the default testConfig.
+	c.ImagePlatformKey = ""
+	c.ImageKeyExchangeKey = nil
+	c.ImageSignaturesDB = nil
+	c.ImageForbiddenSignaturesDB = nil
+
+	action := step.Run(context.Background(), state)
+	assert.Equal(t, multistep.ActionContinue, action, "Step did not pass.")
+
+	assert.Nil(
+		t,
+		d.CreateImageSpec.ShieldedInstanceInitialState,
+		"shieldedInstanceInitialState must be nil so the source disk's initial state is inherited",
+	)
+}
+
 func TestStepCreateImageNonUEFI_image(t *testing.T) {
 	state := testState(t)
 	step := new(StepCreateImage)

--- a/lib/common/shielded_vms.go
+++ b/lib/common/shielded_vms.go
@@ -34,6 +34,16 @@ func FillFileContentBuffer(certOrKeyFile string) (*compute.FileContentBuffer, er
 }
 
 func CreateShieldedVMStateConfig(imagePlatformKey string, imageKeyExchangeKey []string, imageSignaturesDB []string, imageForbiddenSignaturesDB []string) (*compute.InitialStateConfig, error) {
+	// When no Secure Boot signature inputs are configured, return nil so the
+	// caller leaves ShieldedInstanceInitialState unset on the image payload.
+	// Sending an explicit (even empty) InitialStateConfig replaces the
+	// PK/KEKs/db/dbx that would otherwise be inherited from the source disk,
+	// which causes Secure Boot to fail on VMs launched from the resulting
+	// image (UEFI: "Status: Security Violation").
+	if imagePlatformKey == "" && len(imageKeyExchangeKey) == 0 && len(imageSignaturesDB) == 0 && len(imageForbiddenSignaturesDB) == 0 {
+		return nil, nil
+	}
+
 	shieldedVMStateConfig := &compute.InitialStateConfig{}
 	if imagePlatformKey != "" {
 		shieldedData, err := FillFileContentBuffer(imagePlatformKey)

--- a/lib/common/shielded_vms_test.go
+++ b/lib/common/shielded_vms_test.go
@@ -33,7 +33,7 @@ func TestCreateShieldedVMStateConfig_PopulatesFieldsWhenInputsProvided(t *testin
 		t.Fatalf("failed to write fake key: %v", err)
 	}
 
-	tests := []struct {
+	testcases := []struct {
 		name string
 		pk   string
 		keks []string
@@ -46,9 +46,9 @@ func TestCreateShieldedVMStateConfig_PopulatesFieldsWhenInputsProvided(t *testin
 		{name: "dbx only", dbxs: []string{keyPath}},
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			cfg, err := CreateShieldedVMStateConfig(tc.pk, tc.keks, tc.dbs, tc.dbxs)
+	for _, tt := range testcases {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := CreateShieldedVMStateConfig(tt.pk, tt.keks, tt.dbs, tt.dbxs)
 			assert.NoError(t, err)
 			assert.NotNil(t, cfg, "expected non-nil config when at least one signature input is provided")
 		})

--- a/lib/common/shielded_vms_test.go
+++ b/lib/common/shielded_vms_test.go
@@ -1,0 +1,56 @@
+// Copyright IBM Corp. 2013, 2025
+// SPDX-License-Identifier: MPL-2.0
+
+package common
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// When no Secure Boot signature inputs are configured, the helper must return
+// a nil *InitialStateConfig so the caller does not attach an empty
+// shieldedInstanceInitialState to the image insert request. Attaching an
+// empty value overrides the PK/KEKs/db/dbx that would otherwise be inherited
+// from the source disk and breaks Secure Boot on the resulting image.
+func TestCreateShieldedVMStateConfig_NoInputsReturnsNil(t *testing.T) {
+	cfg, err := CreateShieldedVMStateConfig("", nil, nil, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, cfg, "expected nil config when no signature inputs are configured")
+
+	cfg, err = CreateShieldedVMStateConfig("", []string{}, []string{}, []string{})
+	assert.NoError(t, err)
+	assert.Nil(t, cfg, "expected nil config when signature inputs are empty slices")
+}
+
+func TestCreateShieldedVMStateConfig_PopulatesFieldsWhenInputsProvided(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "fake-key")
+	if err := os.WriteFile(keyPath, []byte("fake key data"), 0600); err != nil {
+		t.Fatalf("failed to write fake key: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		pk   string
+		keks []string
+		dbs  []string
+		dbxs []string
+	}{
+		{name: "platform key only", pk: keyPath},
+		{name: "kek only", keks: []string{keyPath}},
+		{name: "db only", dbs: []string{keyPath}},
+		{name: "dbx only", dbxs: []string{keyPath}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := CreateShieldedVMStateConfig(tc.pk, tc.keks, tc.dbs, tc.dbxs)
+			assert.NoError(t, err)
+			assert.NotNil(t, cfg, "expected non-nil config when at least one signature input is provided")
+		})
+	}
+}

--- a/lib/common/shielded_vms_test.go
+++ b/lib/common/shielded_vms_test.go
@@ -50,7 +50,12 @@ func TestCreateShieldedVMStateConfig_PopulatesFieldsWhenInputsProvided(t *testin
 		t.Run(tt.name, func(t *testing.T) {
 			cfg, err := CreateShieldedVMStateConfig(tt.pk, tt.keks, tt.dbs, tt.dbxs)
 			assert.NoError(t, err)
-			assert.NotNil(t, cfg, "expected non-nil config when at least one signature input is provided")
+			assert.NotNil(t, cfg)
+
+			assert.Equal(t, tt.pk != "", cfg.Pk != nil, "Pk presence should match input")
+			assert.Len(t, cfg.Keks, len(tt.keks))
+			assert.Len(t, cfg.Dbs, len(tt.dbs))
+			assert.Len(t, cfg.Dbxs, len(tt.dbxs))
 		})
 	}
 }


### PR DESCRIPTION
### Description

`CreateShieldedVMStateConfig` in `lib/common/shielded_vms.go` returns a non-nil pointer to a zero-value `compute.InitialStateConfig{}` whenever no signature inputs (`image_platform_key`, `image_key_exchange_key`, `image_signatures_db`, `image_forbidden_signatures_db`) are configured. The result is then assigned to `compute.Image.ShieldedInstanceInitialState` in `step_create_image.go`. Because Go's `omitempty` only drops nil pointers (not pointers to empty structs), the body sent to `compute.images.insert` always includes:

```json
"shieldedInstanceInitialState": {}
```

GCP treats an explicit (even empty) `shieldedInstanceInitialState` as *the* initial state for the new image and replaces the PK / KEKs / db / dbx that would otherwise be inherited from the source disk. With no signature databases on the image, UEFI Secure Boot has nothing to validate the bootloader against, and any VM launched from such an image with shielded VM Secure Boot enabled fails on first boot:

```
BdsDxe: failed to load Boot0001 "UEFI Google PersistentDisk " from PciRoot(0x0)/Pci(0x3,0x0)/Scsi(0x1,0x0): Security Violation
```

The regression was introduced in #318 (released in `v1.2.5`). Subsequent work in #333 removed the `UEFI_COMPATIBLE` gate but did not change the empty-struct return path, so `v1.2.6` is still affected. It reproduces by building an image from any source that ships pre-loaded Secure Boot signature databases (Container-Optimized OS, the Shielded-VM-enabled Linux family images, etc.) without supplying any of the four signature parameters, then launching a VM from the result with `--shielded-secure-boot`.

This PR makes `CreateShieldedVMStateConfig` return `nil` when none of the four signature inputs are supplied, so the caller leaves `compute.Image.ShieldedInstanceInitialState` unset and GCP inherits the initial state from the source disk. When at least one signature input is supplied, behaviour is unchanged.

Tests added: unit tests for `CreateShieldedVMStateConfig` covering both branches in `lib/common/shielded_vms_test.go`, and a step-level regression test in `builder/googlecompute/step_create_image_test.go` asserting `CreateImageSpec.ShieldedInstanceInitialState` is `nil` when no signature inputs are configured. The existing `TestStepCreateImageNonUEFI_image` and `TestStepCreateImageUEFI_image` (added in #333) continue to pass — `testConfig` supplies all four signature paths, so the populated branch is still exercised.

### Resolved Issues

N/A — no open issue tracks this specific regression. Related: #318, #333.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

No changes to security controls. This restores the previous behaviour where the source disk's Secure Boot initial state (PK / KEKs / db / dbx) is inherited by the resulting image instead of being silently replaced with empty values, ensuring images built from Shielded-VM-enabled sources continue to boot under Secure Boot enforcement.
