### PR TITLE
fix: support universe regions starting with u- in zoneRegexp

### DIFF
--- a/lib/common/block_device.go
+++ b/lib/common/block_device.go
@@ -267,7 +267,7 @@ func GetRegionFromZone(zone string) (string, error) {
 	return matches[1], nil
 }
 
-var zoneRegexp = regexp.MustCompile("^[a-z]+-[a-z]+[0-9]{1,2}-[a-z]$")
+var zoneRegexp = regexp.MustCompile("^(u-){0,1}[a-z]+-[a-z]+[0-9]{1,2}-[a-z]$")
 
 func IsZoneARegion(zone string) bool {
 	return !zoneRegexp.MatchString(zone)

--- a/lib/common/block_device_test.go
+++ b/lib/common/block_device_test.go
@@ -563,7 +563,18 @@ func TestIsRegion(t *testing.T) {
 		t.Errorf("expected zone %q not to be a region, but isZoneARegion returned %t", zone, isRegion)
 	}
 
+	zone = "u-france-east1-a"
+	isRegion = IsZoneARegion(zone)
+	if isRegion {
+		t.Errorf("expected zone %q not to be a region, but isZoneARegion returned %t", zone, isRegion)
+	}
+
 	region := "us-central1"
+	isRegion = IsZoneARegion(region)
+	if !isRegion {
+		t.Errorf("expected region %q to be a region, but isZoneARegion returned %t", region, isRegion)
+	}
+	region = "u-france-east1"
 	isRegion = IsZoneARegion(region)
 	if !isRegion {
 		t.Errorf("expected region %q to be a region, but isZoneARegion returned %t", region, isRegion)


### PR DESCRIPTION
## Description
This PR updates the zone regular expression (`zoneRegexp`) to correctly support universe regions (which follow the format `u-<country>-<direction><number>-[a-z]`, e.g., `u-france-east1-a`). 

Without this fix, the regex fails to match zones with multiple hyphens before the number, preventing the successful deletion of disks during the cleanup phase.

This ensures both standard regions (europe-west9-a) and universe regions (u-france-east1-a) are properly matched and parsed.

## Related Logs / Error Output
When attempting to delete disks in these regions, the process fails with the following error:

```
==> googlecompute.debian_custom: DiskName: packer-uid
==> googlecompute.debian_custom: Zone: u-france-east1-a
==> googlecompute.debian_custom: Error: googleapi: Error 400: Invalid value for field 'region': 'u-france-east1-a'. Unknown region., invalid
```

