### PR TITLE
fix: authentication failures when using Google Cloud universes

### DIFF
--- a/lib/common/driver_gce.go
+++ b/lib/common/driver_gce.go
@@ -103,7 +103,7 @@ func (ots OauthTokenSource) Token() (*oauth2.Token, error) {
 
 }
 
-func NewClientOptionGoogle(vaultOauth string, impersonatesa string, accessToken string, credentials *google.Credentials, scopes []string) ([]option.ClientOption, error) {
+func NewClientOptionGoogle(vaultOauth string, impersonatesa string, accessToken string, credentials *google.Credentials, scopes []string, universeDomain string) ([]option.ClientOption, error) {
 	var err error
 
 	var opts []option.ClientOption
@@ -112,7 +112,15 @@ func NewClientOptionGoogle(vaultOauth string, impersonatesa string, accessToken 
 		// Auth with Vault Oauth
 		log.Printf("Using Vault to generate Oauth token.")
 		ts := OauthTokenSource{vaultOauth}
-		opts = append(opts, option.WithTokenSource(ts))
+		if universeDomain != "" {
+			creds := &google.Credentials{
+				TokenSource:            ts,
+				UniverseDomainProvider: func() (string, error) { return universeDomain, nil },
+			}
+			opts = append(opts, option.WithCredentials(creds))
+		} else {
+			opts = append(opts, option.WithTokenSource(ts))
+		}
 
 	} else if impersonatesa != "" {
 		log.Printf("[INFO] Using Google Cloud impersonation mechanism")
@@ -123,13 +131,28 @@ func NewClientOptionGoogle(vaultOauth string, impersonatesa string, accessToken 
 		if err != nil {
 			return nil, err
 		}
-		opts = append(opts, option.WithTokenSource(ts))
+		if universeDomain != "" {
+			creds := &google.Credentials{
+				TokenSource:            ts,
+				UniverseDomainProvider: func() (string, error) { return universeDomain, nil },
+			}
+			opts = append(opts, option.WithCredentials(creds))
+		} else {
+			opts = append(opts, option.WithTokenSource(ts))
+		}
 	} else if accessToken != "" {
 		// Auth with static access token
 		log.Printf("[INFO] Using static Google Access Token")
 		token := &oauth2.Token{AccessToken: accessToken}
-		ts := oauth2.StaticTokenSource(token)
-		opts = append(opts, option.WithTokenSource(ts))
+
+		creds := &google.Credentials{
+			TokenSource: oauth2.StaticTokenSource(token),
+		}
+		if universeDomain != "" {
+			creds.UniverseDomainProvider = func() (string, error) { return universeDomain, nil }
+		}
+
+		opts = append(opts, option.WithCredentials(creds))
 	} else if credentials != nil {
 		// Auth with Credentials if provided
 		log.Printf("[INFO] Requesting Google token via credentials...")
@@ -139,13 +162,13 @@ func NewClientOptionGoogle(vaultOauth string, impersonatesa string, accessToken 
 	} else {
 		log.Printf("[INFO] Requesting Google token via GCE API Default Client Token Source...")
 		scopes := append(DriverScopes, "https://www.googleapis.com/auth/cloud-platform")
-		ts, err := google.DefaultTokenSource(context.TODO(), scopes...)
+		creds, err := google.FindDefaultCredentials(context.TODO(), scopes...)
 		if err != nil {
 			return nil, err
 		}
-		opts = append(opts, option.WithTokenSource(ts))
-		// The DefaultClient uses the DefaultTokenSource of the google lib.
-		// The DefaultTokenSource uses the "Application Default Credentials"
+		opts = append(opts, option.WithCredentials(creds))
+		// The DefaultClient uses the FindDefaultCredentials of the google lib.
+		// The FindDefaultCredentials uses the "Application Default Credentials"
 		// It looks for credentials in the following places, preferring the first location found:
 		// 1. A JSON file whose path is specified by the
 		//    GOOGLE_APPLICATION_CREDENTIALS environment variable.
@@ -182,7 +205,7 @@ func buildServiceSpecificOptions(commonOpts []option.ClientOption, customEndpoin
 
 func NewDriverGCE(config GCEDriverConfig) (Driver, error) {
 
-	opts, err := NewClientOptionGoogle(config.VaultOauthEngineName, config.ImpersonateServiceAccountName, config.AccessToken, config.Credentials, config.Scopes)
+	opts, err := NewClientOptionGoogle(config.VaultOauthEngineName, config.ImpersonateServiceAccountName, config.AccessToken, config.Credentials, config.Scopes, config.UniverseDomain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
This PR fixes an authentication issue when using custom universe domains with a `tokenSource`. 

When initializing a `tokenSource`, the universe domain must be explicitly passed to it. Otherwise, it falls back to the default Google universe domain (`googleapis.com`), causing a credential mismatch error and failing to authenticate requests.

In the same way, when using `DefaultTokenSource`, the universe domain was not properly propagated, causing the  same issue.
To resolve this, I switched to using `FindDefaultCredentials`, which natively includes proper support for custom universe domains and correctly parses the environment's credentials.

## Related Logs / Error Output
When the universe domain is not explicitly configured on the `tokenSource`, the following error occurs during the project metadata retrieval:

```text
2026/06/08 22:31:05 failed to get project metadata: Get "https://compute.s3nsapis.fr/compute/v1/projects/s3ns%3Aredacted-project?alt=json&prettyPrint=false": the configured universe domain ("s3nsapis.fr") does not match the universe domain found in the credentials ("googleapis.com"). If you haven't configured the universe domain explicitly, "googleapis.com" is the default.
```



