### PR TITLE
Update instance name logic in GCP packer plugin startup script

### DIFF
--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -26,9 +26,10 @@ GetMetadata () {
 }
 
 ZONE=$(basename $(GetMetadata zone))
+INSTANCE_NAME=$(basename $(GetMetadata name))
 
 SetMetadata () {
-  gcloud compute instances add-metadata ${HOSTNAME} --metadata ${1}=${2} --zone ${ZONE}
+  gcloud compute instances add-metadata ${INSTANCE_NAME} --metadata ${1}=${2} --zone ${ZONE}
 }
 
 STARTUPSCRIPT=$(GetMetadata attributes/%[1]s)

--- a/builder/googlecompute/startup.go
+++ b/builder/googlecompute/startup.go
@@ -26,7 +26,7 @@ GetMetadata () {
 }
 
 ZONE=$(basename $(GetMetadata zone))
-INSTANCE_NAME=$(basename $(GetMetadata name))
+INSTANCE_NAME=$(GetMetadata name)
 
 SetMetadata () {
   gcloud compute instances add-metadata ${INSTANCE_NAME} --metadata ${1}=${2} --zone ${ZONE}


### PR DESCRIPTION
Get instance name via metadata server instead of using ${HOSTNAME}

Some Linux distros on GCP allows the ${HOSTNAME} to resolve to the FQDN by default (ie: `{NAME}.{ZONE}.c.{PROJECT}.internal`) which causes the startup script to throw an error during completion, even if all other tasks were successful.  This errors results in the metadata never being updated and the startup script running forever.

This change removes the only reference to the HOSTNAME env var, and replaces it with the name returned by the GCP metadata server (similar to ZONE in this same file).