### PR TITLE
Fit disk size to source image by default

### DIFF
--- a/.web-docs/components/builder/googlecompute/README.md
+++ b/.web-docs/components/builder/googlecompute/README.md
@@ -70,7 +70,8 @@ builder.
 
 - `disk_name` (string) - The name of the disk, if unset the instance name will be used.
 
-- `disk_size` (int64) - The size of the disk in GB. This defaults to 20, which is 20GB.
+- `disk_size` (int64) - The size of the disk in GB. Defaults to the size of the source image,
+  or 20GB if the source image does not report a size.
 
 - `disk_type` (string) - Type of disk used to back your instance, like pd-ssd or pd-standard.
   Defaults to pd-standard.

--- a/builder/googlecompute/config.go
+++ b/builder/googlecompute/config.go
@@ -26,6 +26,9 @@ import (
 	"github.com/hashicorp/packer-plugin-sdk/uuid"
 )
 
+// used when disk_size is unset and the source image does not report its size
+const defaultDiskSizeGb int64 = 20
+
 // used for ImageName and ImageFamily
 var validImageName = regexp.MustCompile(`^[a-z]([-a-z0-9]{0,61}[a-z0-9])?$`)
 
@@ -56,7 +59,8 @@ type Config struct {
 	DisableDefaultServiceAccount bool `mapstructure:"disable_default_service_account" required:"false"`
 	// The name of the disk, if unset the instance name will be used.
 	DiskName string `mapstructure:"disk_name" required:"false"`
-	// The size of the disk in GB. This defaults to 20, which is 20GB.
+	// The size of the disk in GB. Defaults to the size of the source image,
+	// or 20GB if the source image does not report a size.
 	DiskSizeGb int64 `mapstructure:"disk_size" required:"false"`
 	// Type of disk used to back your instance, like pd-ssd or pd-standard.
 	// Defaults to pd-standard.
@@ -480,10 +484,6 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 
 	if c.NetworkProjectId == "" {
 		c.NetworkProjectId = c.ProjectId
-	}
-
-	if c.DiskSizeGb == 0 {
-		c.DiskSizeGb = 20
 	}
 
 	if c.DiskType == "" {

--- a/builder/googlecompute/config_test.go
+++ b/builder/googlecompute/config_test.go
@@ -997,3 +997,29 @@ const testAccountContent = `{
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
   "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/12345-compute%40developer.gserviceaccount.com"
 }`
+
+func TestConfigPrepare_DiskSizeDefault(t *testing.T) {
+	raw, tempfile := testConfig(t)
+	defer os.Remove(tempfile)
+
+	// disk_size is absent from raw, so it must stay 0 to signal "match the
+	// source image" to StepCreateInstance.
+	var c Config
+	_, errs := c.Prepare(raw)
+	if errs != nil {
+		t.Fatalf("bad: %#v", errs)
+	}
+	if c.DiskSizeGb != 0 {
+		t.Fatalf("unset disk_size should stay 0, got %d", c.DiskSizeGb)
+	}
+
+	raw["disk_size"] = 30
+	var explicit Config
+	_, errs = explicit.Prepare(raw)
+	if errs != nil {
+		t.Fatalf("bad: %#v", errs)
+	}
+	if explicit.DiskSizeGb != 30 {
+		t.Fatalf("explicit disk_size should be preserved, got %d", explicit.DiskSizeGb)
+	}
+}

--- a/builder/googlecompute/step_create_instance.go
+++ b/builder/googlecompute/step_create_instance.go
@@ -116,6 +116,22 @@ func getImage(c *Config, d common.Driver) (*common.Image, error) {
 	}
 }
 
+func resolveDiskSize(configured int64, sourceImage *common.Image, ui packersdk.Ui) int64 {
+	// If user configured a disk size, return it as-is.
+	if configured != 0 {
+		return configured
+	}
+
+	// The source image size is unknown, so fall back to the historical default.
+	if sourceImage.SizeGb == 0 {
+		ui.Say(fmt.Sprintf("Source image %s does not report a disk size, using default disk size of %dGB", sourceImage.Name, defaultDiskSizeGb))
+		return defaultDiskSizeGb
+	}
+
+	ui.Say(fmt.Sprintf("Setting disk size to %dGB to match source image %s", sourceImage.SizeGb, sourceImage.Name))
+	return sourceImage.SizeGb
+}
+
 // Run executes the Packer build step that creates a GCE instance.
 func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
 	c := state.Get("config").(*Config)
@@ -146,6 +162,8 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 	}
 
 	ui.Say(fmt.Sprintf("Using image: %s", sourceImage.Name))
+
+	diskSizeGb := resolveDiskSize(c.DiskSizeGb, sourceImage, ui)
 
 	if sourceImage.IsWindows() && c.Comm.Type == "winrm" && c.Comm.WinRMPassword == "" {
 		state.Put("create_windows_password", true)
@@ -184,7 +202,7 @@ func (s *StepCreateInstance) Run(ctx context.Context, state multistep.StateBag) 
 		Description:                  "New instance created by Packer",
 		DisableDefaultServiceAccount: c.DisableDefaultServiceAccount,
 		DiskName:                     c.DiskName,
-		DiskSizeGb:                   c.DiskSizeGb,
+		DiskSizeGb:                   diskSizeGb,
 		DiskType:                     c.DiskType,
 		DiskEncryptionKey:            c.DiskEncryptionKey,
 		EnableNestedVirtualization:   c.EnableNestedVirtualization,

--- a/builder/googlecompute/step_create_instance_test.go
+++ b/builder/googlecompute/step_create_instance_test.go
@@ -4,6 +4,7 @@
 package googlecompute
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/hashicorp/packer-plugin-googlecompute/lib/common"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 	"github.com/hashicorp/packer-plugin-sdk/packerbuilderdata"
 	"github.com/hashicorp/packer-plugin-sdk/template/config"
 	"github.com/stretchr/testify/assert"
@@ -530,4 +532,73 @@ func TestImage_IsWindows(t *testing.T) {
 
 	i = StubImage("foo", "foo-project", []string{"license-foo", "windows-license"}, 100)
 	assert.True(t, i.IsWindows())
+}
+
+func TestResolveDiskSize(t *testing.T) {
+	cases := []struct {
+		Name        string
+		Configured  int64
+		ImageSizeGb int64
+		Expect      int64
+		ExpectSay   string
+	}{
+		{"unset uses image size", 0, 50, 50,
+			"Setting disk size to 50GB to match source image test-image"},
+		{"unset with unknown image size uses the default", 0, 0, 20,
+			"Source image test-image does not report a disk size, using default disk size of 20GB"},
+		{"explicit larger than image is kept", 100, 50, 100, ""},
+		{"explicit smaller than image is kept", 20, 50, 20, ""},
+		{"explicit equal to image is kept", 50, 50, 50, ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			out := new(bytes.Buffer)
+			ui := &packersdk.BasicUi{
+				Reader: new(bytes.Buffer),
+				Writer: out,
+			}
+			image := StubImage("test-image", "test-project", []string{}, tc.ImageSizeGb)
+
+			got := resolveDiskSize(tc.Configured, image, ui)
+
+			assert.Equal(t, tc.Expect, got, "Incorrect resolved disk size.")
+			if tc.ExpectSay != "" {
+				assert.Contains(t, out.String(), tc.ExpectSay)
+			} else {
+				assert.Empty(t, out.String(), "Step should not have reported anything.")
+			}
+		})
+	}
+}
+
+func TestStepCreateInstance_diskSize(t *testing.T) {
+	cases := []struct {
+		Name       string
+		Configured int64
+		Expect     int64
+	}{
+		{"unset disk_size matches the source image", 0, 50},
+		{"explicit disk_size is passed through", 100, 100},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			state := testState(t)
+			step := new(StepCreateInstance)
+			defer step.Cleanup(state)
+
+			state.Put("ssh_public_key", "key")
+
+			c := state.Get("config").(*Config)
+			c.DiskSizeGb = tc.Configured
+
+			d := state.Get("driver").(*common.DriverMock)
+			d.GetImageResult = StubImage("test-image", "test-project", []string{}, 50)
+
+			assert.Equal(t, multistep.ActionContinue, step.Run(context.Background(), state), "Step should have passed and continued.")
+			assert.Equal(t, tc.Expect, d.RunInstanceConfig.DiskSizeGb, "Incorrect disk size passed to driver.")
+			assert.Equal(t, tc.Configured, c.DiskSizeGb, "Config disk size should not be mutated.")
+		})
+	}
 }

--- a/docs-partials/builder/googlecompute/Config-not-required.mdx
+++ b/docs-partials/builder/googlecompute/Config-not-required.mdx
@@ -16,7 +16,8 @@
 
 - `disk_name` (string) - The name of the disk, if unset the instance name will be used.
 
-- `disk_size` (int64) - The size of the disk in GB. This defaults to 20, which is 20GB.
+- `disk_size` (int64) - The size of the disk in GB. Defaults to the size of the source image,
+  or 20GB if the source image does not report a size.
 
 - `disk_type` (string) - Type of disk used to back your instance, like pd-ssd or pd-standard.
   Defaults to pd-standard.


### PR DESCRIPTION
----

### Description
I found that this builder will use 20GB when not specified image `disk_size` and I met an issue that my source image is using a disk with 430GB which GCE reports me 20GB is unavailable to build. Working around it means looking up the image's size and hardcoding it into the template, so I think defaulting to the source image size is the better behavior.

With the help of Claude, I made `Config.Prepare` stop defaulting `disk_size` to 20, which lets an unset value reach the build as `0`. `StepCreateInstance` then resolves it against `sourceImage.SizeGb`, which the driver already populates from the image's `diskSizeGb`. If the source image reports no size, it falls back to a new `defaultDiskSizeGb` constant of 20GB, matching the original behavior.

An explicitly set `disk_size` is passed through unchanged, including a value smaller than the source image — that still fails at the GCE API exactly as it does today. I left it that way deliberately, but I'm happy to add a clearer error message or grow the disk automatically if reviewers prefer. Maybe we can add a fail-fast mechanism in `resolveDiskSize()`.

One behavior change worth flagging: with `disk_size` unset and a source image smaller than 20GB, the boot disk is now the image's size rather than 20GB. Builds that relied on that extra headroom will need to set `disk_size` explicitly.

Also added `TestResolveDiskSize`, `TestStepCreateInstance_diskSize`, and `TestConfigPrepare_DiskSizeDefault`. `go test ./...` passes and the docs were regenerated with `make generate`.

### Resolved Issues
No. I didn't create an issue before making this change.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

No. This reuses the existing code path that fetches image information.

